### PR TITLE
기록 저장 화면 레이아웃 및 기록 저장 기능

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -70,6 +70,7 @@ dependencies {
 
     implementation("com.google.firebase:firebase-auth-ktx")
     implementation("com.google.firebase:firebase-analytics")
+    implementation("com.google.firebase:firebase-storage")
     implementation("androidx.navigation:navigation-fragment-ktx:2.7.6")
     implementation("androidx.navigation:navigation-ui-ktx:2.7.6")
     implementation("androidx.fragment:fragment-ktx:1.6.2")

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
     id("com.android.application")
     id("org.jetbrains.kotlin.android")
     id("com.google.gms.google-services")
+    id("kotlinx-serialization")
     kotlin("kapt")
 }
 
@@ -80,4 +81,8 @@ dependencies {
     implementation("com.google.android.gms:play-services-location:21.0.1")
 
     implementation("com.github.bumptech.glide:glide:4.16.0")
+
+    implementation("com.squareup.retrofit2:retrofit:2.9.0")
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.2")
+    implementation("com.jakewharton.retrofit:retrofit2-kotlinx-serialization-converter:1.0.0")
 }

--- a/app/src/main/java/com/treasurehunt/data/network/LogClient.kt
+++ b/app/src/main/java/com/treasurehunt/data/network/LogClient.kt
@@ -1,0 +1,28 @@
+package com.treasurehunt.data.network
+
+
+import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFactory
+import kotlinx.serialization.json.Json
+import okhttp3.MediaType
+import okhttp3.MediaType.Companion.toMediaType
+import retrofit2.Retrofit
+
+object LogClient {
+
+    private const val BASE_URL =
+        "https://treasurehunt-32565-default-rtdb.asia-southeast1.firebasedatabase.app/"
+    private val jsonRule = Json {
+        isLenient = true
+        ignoreUnknownKeys = true
+        coerceInputValues = true
+    }
+    private val jsonType: MediaType = "apapplication/json".toMediaType()
+
+    fun create(): LogService {
+        return Retrofit.Builder()
+            .baseUrl(BASE_URL)
+            .addConverterFactory(jsonRule.asConverterFactory(jsonType))
+            .build()
+            .create(LogService::class.java)
+    }
+}

--- a/app/src/main/java/com/treasurehunt/data/network/LogService.kt
+++ b/app/src/main/java/com/treasurehunt/data/network/LogService.kt
@@ -10,7 +10,7 @@ interface LogService {
     suspend fun getLogs(): List<LogModel>
 
     @POST("logs.json")
-    suspend fun addLogs(@Body logModel: LogModel)
+    suspend fun addLog(@Body logModel: LogModel)
 }
 
 @Serializable

--- a/app/src/main/java/com/treasurehunt/data/network/LogService.kt
+++ b/app/src/main/java/com/treasurehunt/data/network/LogService.kt
@@ -1,0 +1,24 @@
+package com.treasurehunt.data.network
+
+import kotlinx.serialization.Serializable
+import retrofit2.http.Body
+import retrofit2.http.GET
+import retrofit2.http.POST
+
+interface LogService {
+    @GET("logs.json")
+    suspend fun getLogs(): List<LogModel>
+
+    @POST("logs.json")
+    suspend fun addLogs(@Body logModel: LogModel)
+}
+
+@Serializable
+data class LogModel (
+    val createdDate: Long,
+    val images: List<Boolean>,
+    val place: Int,
+    val text: String,
+    val theme: Int,
+    val user: Int
+)

--- a/app/src/main/java/com/treasurehunt/data/network/LogService.kt
+++ b/app/src/main/java/com/treasurehunt/data/network/LogService.kt
@@ -16,7 +16,7 @@ interface LogService {
 @Serializable
 data class LogModel (
     val createdDate: Long,
-    val images: List<Boolean>,
+    val images: List<String>,
     val place: Int,
     val text: String,
     val theme: Int,

--- a/app/src/main/java/com/treasurehunt/data/network/LogService.kt
+++ b/app/src/main/java/com/treasurehunt/data/network/LogService.kt
@@ -14,7 +14,7 @@ interface LogService {
 }
 
 @Serializable
-data class LogModel (
+data class LogModel(
     val createdDate: Long,
     val images: List<String>,
     val place: Int,

--- a/app/src/main/java/com/treasurehunt/ui/home/HomeActivity.kt
+++ b/app/src/main/java/com/treasurehunt/ui/home/HomeActivity.kt
@@ -17,24 +17,18 @@ class HomeActivity : AppCompatActivity() {
         binding = ActivityHomeBinding.inflate(layoutInflater)
         setContentView(binding.root)
 
-        val navHostFragment = supportFragmentManager.findFragmentById(R.id.fcv_home) as NavHostFragment
+        val navHostFragment =
+            supportFragmentManager.findFragmentById(R.id.fcv_home) as NavHostFragment
         val navController = navHostFragment.navController
 
         navController.addOnDestinationChangedListener { _, destination, _ ->
 
-            when (destination.id) {
-                R.id.splashFragment -> {
-                    binding.bnvHome.visibility = View.GONE
-                }
-                R.id.logInFragment -> {
-                    binding.bnvHome.visibility = View.GONE
-                }
-                R.id.saveLogFragment -> {
-                    binding.bnvHome.visibility = View.GONE
-                }
-                else -> {
-                    binding.bnvHome.visibility = View.VISIBLE
-                }
+            binding.bnvHome.visibility = when (destination.id) {
+                R.id.splashFragment -> View.GONE
+                R.id.logInFragment -> View.GONE
+                R.id.saveLogFragment -> View.GONE
+                R.id.saveLogMapFragment -> View.GONE
+                else -> View.VISIBLE
             }
         }
     }

--- a/app/src/main/java/com/treasurehunt/ui/home/HomeActivity.kt
+++ b/app/src/main/java/com/treasurehunt/ui/home/HomeActivity.kt
@@ -29,6 +29,9 @@ class HomeActivity : AppCompatActivity() {
                 R.id.logInFragment -> {
                     binding.bnvHome.visibility = View.GONE
                 }
+                R.id.saveLogFragment -> {
+                    binding.bnvHome.visibility = View.GONE
+                }
                 else -> {
                     binding.bnvHome.visibility = View.VISIBLE
                 }

--- a/app/src/main/java/com/treasurehunt/ui/login/LogInFragment.kt
+++ b/app/src/main/java/com/treasurehunt/ui/login/LogInFragment.kt
@@ -8,10 +8,12 @@ import android.view.ViewGroup
 import android.widget.Toast
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
+import androidx.navigation.fragment.findNavController
 import com.navercorp.nid.NaverIdLoginSDK
 import com.navercorp.nid.oauth.NidOAuthBehavior
 import com.navercorp.nid.oauth.OAuthLoginCallback
 import com.treasurehunt.BuildConfig
+import com.treasurehunt.R
 import com.treasurehunt.databinding.FragmentLoginBinding
 
 private const val NAVER_LOGIN_CLIENT_ID = BuildConfig.NAVER_LOGIN_CLIENT_ID
@@ -53,7 +55,9 @@ class LogInFragment : Fragment() {
         binding.btnNaverLogin.setOnClickListener {
             NaverIdLoginSDK.behavior = NidOAuthBehavior.NAVERAPP
             NaverIdLoginSDK.authenticate(requireContext(), object : OAuthLoginCallback {
-                override fun onSuccess() {}
+                override fun onSuccess() {
+                    findNavController().navigate(R.id.action_logInFragment_to_saveLogFragment)
+                }
                 override fun onFailure(httpStatus: Int, message: String) {
                     val errorCode = NaverIdLoginSDK.getLastErrorCode().code
                     val errorDescription = NaverIdLoginSDK.getLastErrorDescription()

--- a/app/src/main/java/com/treasurehunt/ui/login/LogInFragment.kt
+++ b/app/src/main/java/com/treasurehunt/ui/login/LogInFragment.kt
@@ -55,9 +55,7 @@ class LogInFragment : Fragment() {
         binding.btnNaverLogin.setOnClickListener {
             NaverIdLoginSDK.behavior = NidOAuthBehavior.NAVERAPP
             NaverIdLoginSDK.authenticate(requireContext(), object : OAuthLoginCallback {
-                override fun onSuccess() {
-                    findNavController().navigate(R.id.action_logInFragment_to_saveLogFragment)
-                }
+                override fun onSuccess() {}
                 override fun onFailure(httpStatus: Int, message: String) {
                     val errorCode = NaverIdLoginSDK.getLastErrorCode().code
                     val errorDescription = NaverIdLoginSDK.getLastErrorDescription()

--- a/app/src/main/java/com/treasurehunt/ui/savelog/SaveLogFragment.kt
+++ b/app/src/main/java/com/treasurehunt/ui/savelog/SaveLogFragment.kt
@@ -14,6 +14,7 @@ import androidx.core.net.toUri
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
+import androidx.navigation.fragment.findNavController
 import com.google.firebase.Firebase
 import com.google.firebase.storage.storage
 import com.naver.maps.map.LocationTrackingMode
@@ -28,7 +29,6 @@ import com.treasurehunt.databinding.FragmentSavelogBinding
 import com.treasurehunt.ui.savelog.adapter.SaveLogAdapter
 import com.treasurehunt.util.showSnackbar
 import kotlinx.coroutines.launch
-import java.sql.Timestamp
 import java.time.LocalDateTime
 import java.time.ZoneId
 import java.util.Date
@@ -81,6 +81,7 @@ class SaveLogFragment : Fragment(), OnMapReadyCallback {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        moveMap()
         initAdapter()
         setAddImage()
         loadMap()
@@ -94,6 +95,12 @@ class SaveLogFragment : Fragment(), OnMapReadyCallback {
 
     private fun initAdapter() {
         binding.rvPhoto.adapter = recordAdapter
+    }
+
+    private fun moveMap() {
+        binding.ibFullScreen.setOnClickListener {
+            findNavController().navigate(R.id.action_saveLogFragment_to_saveLogMapFragment)
+        }
     }
 
     private fun setAddImage() {

--- a/app/src/main/java/com/treasurehunt/ui/savelog/SaveLogFragment.kt
+++ b/app/src/main/java/com/treasurehunt/ui/savelog/SaveLogFragment.kt
@@ -1,18 +1,18 @@
 package com.treasurehunt.ui.savelog
 
+import android.annotation.SuppressLint
 import android.content.pm.PackageManager
 import android.net.Uri
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.Toast
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.core.content.ContextCompat
+import androidx.core.net.toUri
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import com.google.firebase.Firebase
-import com.google.firebase.storage.ktx.storage
 import com.google.firebase.storage.storage
 import com.naver.maps.map.LocationTrackingMode
 import com.naver.maps.map.MapFragment
@@ -23,7 +23,6 @@ import com.treasurehunt.R
 import com.treasurehunt.databinding.FragmentSavelogBinding
 import com.treasurehunt.ui.savelog.adapter.SaveLogAdapter
 import com.treasurehunt.util.showSnackbar
-import kotlinx.coroutines.flow.first
 import java.text.SimpleDateFormat
 import java.util.Date
 
@@ -33,7 +32,6 @@ class SaveLogFragment : Fragment(), OnMapReadyCallback {
     private val binding get() = _binding!!
     private val viewModel: SaveLogViewModel by viewModels()
     private val recordAdapter = SaveLogAdapter { imageModel -> viewModel.removeImage(imageModel) }
-    private val uriList: MutableList<Uri> = arrayListOf()
     private val imageLauncher =
         registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
             if (result.data?.clipData != null) {
@@ -44,7 +42,6 @@ class SaveLogFragment : Fragment(), OnMapReadyCallback {
                 }
                 for (i in 0 until count) {
                     viewModel.addImage(ImageModel(result.data?.clipData!!.getItemAt(i).uri.toString()))
-                    uriList.add(result.data?.clipData!!.getItemAt(i).uri)
                 }
             } else if (result.data?.data != null) {
                 if (viewModel.images.value.size + 1 > 5) {
@@ -52,20 +49,7 @@ class SaveLogFragment : Fragment(), OnMapReadyCallback {
                     return@registerForActivityResult
                 }
                 val uri = result?.data?.data
-                if (uri != null) {
-                    uriList.add(uri)
-                }
                 viewModel.addImage(ImageModel(uri.toString()))
-            }
-            binding.btnSave.setOnClickListener {
-                for (i in 0 until uriList.size) {
-                    uploadImage(uriList[i], i)
-                    try {
-                        Thread.sleep(500)
-                    } catch (e: InterruptedException) {
-                        e.printStackTrace()
-                    }
-                }
             }
         }
 
@@ -93,6 +77,7 @@ class SaveLogFragment : Fragment(), OnMapReadyCallback {
         initAdapter()
         setAddImage()
         loadMap()
+        saveLog()
     }
 
     override fun onDestroyView() {
@@ -110,6 +95,15 @@ class SaveLogFragment : Fragment(), OnMapReadyCallback {
         }
     }
 
+    private fun saveLog() {
+        binding.btnSave.setOnClickListener {
+            for (i in 0 until viewModel.images.value.size) {
+                uploadImage(viewModel.images.value[0].url.toUri(), i)
+            }
+        }
+    }
+
+    @SuppressLint("SimpleDateFormat")
     private fun uploadImage(uri: Uri, count: Int) {
         val storage = Firebase.storage
         val storageRef = storage.getReference("uid/image")

--- a/app/src/main/java/com/treasurehunt/ui/savelog/SaveLogFragment.kt
+++ b/app/src/main/java/com/treasurehunt/ui/savelog/SaveLogFragment.kt
@@ -38,7 +38,7 @@ class SaveLogFragment : Fragment(), OnMapReadyCallback {
     private var _binding: FragmentSavelogBinding? = null
     private val binding get() = _binding!!
     private val viewModel: SaveLogViewModel by viewModels()
-    private val recordAdapter = SaveLogAdapter { imageModel -> viewModel.removeImage(imageModel) }
+    private val saveLogAdapter = SaveLogAdapter { imageModel -> viewModel.removeImage(imageModel) }
     private val imageLauncher =
         registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
             if (result.data?.clipData != null) {
@@ -81,7 +81,7 @@ class SaveLogFragment : Fragment(), OnMapReadyCallback {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        moveMap()
+        showMapFullScreen()
         initAdapter()
         setAddImage()
         loadMap()
@@ -94,10 +94,10 @@ class SaveLogFragment : Fragment(), OnMapReadyCallback {
     }
 
     private fun initAdapter() {
-        binding.rvPhoto.adapter = recordAdapter
+        binding.rvPhoto.adapter = saveLogAdapter
     }
 
-    private fun moveMap() {
+    private fun showMapFullScreen() {
         binding.ibFullScreen.setOnClickListener {
             findNavController().navigate(R.id.action_saveLogFragment_to_saveLogMapFragment)
         }
@@ -126,7 +126,7 @@ class SaveLogFragment : Fragment(), OnMapReadyCallback {
                 images.add("${viewModel.images.value[i].url.replace("[^0-9]".toRegex(), "")}.png")
             }
             lifecycleScope.launch {
-                LogClient.create().addLogs(LogModel(createdDate, images, place, text, theme, user))
+                LogClient.create().addLog(LogModel(createdDate, images, place, text, theme, user))
             }
         }
     }

--- a/app/src/main/java/com/treasurehunt/ui/savelog/SaveLogFragment.kt
+++ b/app/src/main/java/com/treasurehunt/ui/savelog/SaveLogFragment.kt
@@ -2,6 +2,7 @@ package com.treasurehunt.ui.savelog
 
 import android.content.pm.PackageManager
 import android.os.Bundle
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -9,6 +10,7 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
+import com.google.android.material.snackbar.Snackbar
 import com.naver.maps.map.LocationTrackingMode
 import com.naver.maps.map.MapFragment
 import com.naver.maps.map.NaverMap
@@ -17,6 +19,7 @@ import com.naver.maps.map.util.FusedLocationSource
 import com.treasurehunt.R
 import com.treasurehunt.databinding.FragmentSavelogBinding
 import com.treasurehunt.ui.savelog.adapter.SaveLogAdapter
+import com.treasurehunt.util.showSnackbar
 
 class SaveLogFragment : Fragment(), OnMapReadyCallback {
 
@@ -28,10 +31,18 @@ class SaveLogFragment : Fragment(), OnMapReadyCallback {
         registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
             if (result.data?.clipData != null) {
                 val count = result.data?.clipData!!.itemCount
+                if (viewModel.images.value.size + count > 5) {
+                    binding.root.showSnackbar(R.string.log_sb_warning_count)
+                    return@registerForActivityResult
+                }
                 for (i in 0 until count) {
                     viewModel.addImage(ImageModel(result.data?.clipData!!.getItemAt(i).uri.toString()))
                 }
             } else if (result.data?.data != null) {
+                if (viewModel.images.value.size + 1 > 5) {
+                    binding.root.showSnackbar(R.string.log_sb_warning_count)
+                    return@registerForActivityResult
+                }
                 viewModel.addImage(ImageModel(result.data?.data.toString()))
             }
         }

--- a/app/src/main/java/com/treasurehunt/ui/savelog/SaveLogFragment.kt
+++ b/app/src/main/java/com/treasurehunt/ui/savelog/SaveLogFragment.kt
@@ -81,7 +81,7 @@ class SaveLogFragment : Fragment(), OnMapReadyCallback {
     private fun setImageLauncher(result: ActivityResult) {
         if (result.data?.clipData != null) {
             val count = result.data?.clipData!!.itemCount
-            if (viewModel.images.value.size + count > 5) {
+            if (viewModel.images.value.size + count > MAX_COUNT) {
                 binding.root.showSnackbar(R.string.savelog_sb_warning_count)
                 return
             }
@@ -89,7 +89,7 @@ class SaveLogFragment : Fragment(), OnMapReadyCallback {
                 viewModel.addImage(ImageModel(result.data?.clipData!!.getItemAt(i).uri.toString()))
             }
         } else if (result.data?.data != null) {
-            if (viewModel.images.value.size + 1 > 5) {
+            if (viewModel.images.value.size + 1 > MAX_COUNT) {
                 binding.root.showSnackbar(R.string.savelog_sb_warning_count)
                 return
             }
@@ -193,5 +193,6 @@ class SaveLogFragment : Fragment(), OnMapReadyCallback {
 
     companion object {
         private const val LOCATION_PERMISSION_REQUEST_CODE = 1001
+        private const val MAX_COUNT = 5
     }
 }

--- a/app/src/main/java/com/treasurehunt/ui/savelog/SaveLogFragment.kt
+++ b/app/src/main/java/com/treasurehunt/ui/savelog/SaveLogFragment.kt
@@ -7,16 +7,15 @@ import android.view.ViewGroup
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
-import com.treasurehunt.databinding.FragmentLogBinding
-import com.treasurehunt.ui.login.LogViewModel
-import com.treasurehunt.ui.savelog.adapter.LogAdapter
+import com.treasurehunt.databinding.FragmentSavelogBinding
+import com.treasurehunt.ui.savelog.adapter.SaveLogAdapter
 
-class LogFragment : Fragment() {
+class SaveLogFragment : Fragment() {
 
-    private var _binding: FragmentLogBinding? = null
+    private var _binding: FragmentSavelogBinding? = null
     private val binding get() = _binding!!
-    private val viewModel: LogViewModel by viewModels()
-    private val recordAdapter = LogAdapter { imageModel -> viewModel.removeImage(imageModel) }
+    private val viewModel: SaveLogViewModel by viewModels()
+    private val recordAdapter = SaveLogAdapter { imageModel -> viewModel.removeImage(imageModel) }
     private val imageLauncher =
         registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
             if (result.data?.clipData != null) {
@@ -34,7 +33,7 @@ class LogFragment : Fragment() {
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
-        _binding = FragmentLogBinding.inflate(inflater, container, false)
+        _binding = FragmentSavelogBinding.inflate(inflater, container, false)
         binding.lifecycleOwner = viewLifecycleOwner
         binding.viewModel = viewModel
         return binding.root

--- a/app/src/main/java/com/treasurehunt/ui/savelog/SaveLogFragment.kt
+++ b/app/src/main/java/com/treasurehunt/ui/savelog/SaveLogFragment.kt
@@ -8,6 +8,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.activity.result.ActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.core.content.ContextCompat
 import androidx.core.net.toUri
@@ -41,23 +42,7 @@ class SaveLogFragment : Fragment(), OnMapReadyCallback {
     private val saveLogAdapter = SaveLogAdapter { imageModel -> viewModel.removeImage(imageModel) }
     private val imageLauncher =
         registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
-            if (result.data?.clipData != null) {
-                val count = result.data?.clipData!!.itemCount
-                if (viewModel.images.value.size + count > 5) {
-                    binding.root.showSnackbar(R.string.savelog_sb_warning_count)
-                    return@registerForActivityResult
-                }
-                for (i in 0 until count) {
-                    viewModel.addImage(ImageModel(result.data?.clipData!!.getItemAt(i).uri.toString()))
-                }
-            } else if (result.data?.data != null) {
-                if (viewModel.images.value.size + 1 > 5) {
-                    binding.root.showSnackbar(R.string.savelog_sb_warning_count)
-                    return@registerForActivityResult
-                }
-                val uri = result?.data?.data
-                viewModel.addImage(ImageModel(uri.toString()))
-            }
+            setImageLauncher(result)
         }
 
     private lateinit var map: NaverMap
@@ -91,6 +76,26 @@ class SaveLogFragment : Fragment(), OnMapReadyCallback {
     override fun onDestroyView() {
         super.onDestroyView()
         _binding = null
+    }
+
+    private fun setImageLauncher(result: ActivityResult) {
+        if (result.data?.clipData != null) {
+            val count = result.data?.clipData!!.itemCount
+            if (viewModel.images.value.size + count > 5) {
+                binding.root.showSnackbar(R.string.savelog_sb_warning_count)
+                return
+            }
+            for (i in 0 until count) {
+                viewModel.addImage(ImageModel(result.data?.clipData!!.getItemAt(i).uri.toString()))
+            }
+        } else if (result.data?.data != null) {
+            if (viewModel.images.value.size + 1 > 5) {
+                binding.root.showSnackbar(R.string.savelog_sb_warning_count)
+                return
+            }
+            val uri = result.data?.data
+            viewModel.addImage(ImageModel(uri.toString()))
+        }
     }
 
     private fun initAdapter() {

--- a/app/src/main/java/com/treasurehunt/ui/savelog/SaveLogFragment.kt
+++ b/app/src/main/java/com/treasurehunt/ui/savelog/SaveLogFragment.kt
@@ -2,7 +2,6 @@ package com.treasurehunt.ui.savelog
 
 import android.content.pm.PackageManager
 import android.os.Bundle
-import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -10,7 +9,6 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
-import com.google.android.material.snackbar.Snackbar
 import com.naver.maps.map.LocationTrackingMode
 import com.naver.maps.map.MapFragment
 import com.naver.maps.map.NaverMap
@@ -32,7 +30,7 @@ class SaveLogFragment : Fragment(), OnMapReadyCallback {
             if (result.data?.clipData != null) {
                 val count = result.data?.clipData!!.itemCount
                 if (viewModel.images.value.size + count > 5) {
-                    binding.root.showSnackbar(R.string.log_sb_warning_count)
+                    binding.root.showSnackbar(R.string.savelog_sb_warning_count)
                     return@registerForActivityResult
                 }
                 for (i in 0 until count) {
@@ -40,7 +38,7 @@ class SaveLogFragment : Fragment(), OnMapReadyCallback {
                 }
             } else if (result.data?.data != null) {
                 if (viewModel.images.value.size + 1 > 5) {
-                    binding.root.showSnackbar(R.string.log_sb_warning_count)
+                    binding.root.showSnackbar(R.string.savelog_sb_warning_count)
                     return@registerForActivityResult
                 }
                 viewModel.addImage(ImageModel(result.data?.data.toString()))

--- a/app/src/main/java/com/treasurehunt/ui/savelog/SaveLogFragment.kt
+++ b/app/src/main/java/com/treasurehunt/ui/savelog/SaveLogFragment.kt
@@ -1,16 +1,24 @@
 package com.treasurehunt.ui.savelog
 
+import android.content.pm.PackageManager
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
+import com.naver.maps.map.LocationTrackingMode
+import com.naver.maps.map.MapFragment
+import com.naver.maps.map.NaverMap
+import com.naver.maps.map.OnMapReadyCallback
+import com.naver.maps.map.util.FusedLocationSource
+import com.treasurehunt.R
 import com.treasurehunt.databinding.FragmentSavelogBinding
 import com.treasurehunt.ui.savelog.adapter.SaveLogAdapter
 
-class SaveLogFragment : Fragment() {
+class SaveLogFragment : Fragment(), OnMapReadyCallback {
 
     private var _binding: FragmentSavelogBinding? = null
     private val binding get() = _binding!!
@@ -28,6 +36,14 @@ class SaveLogFragment : Fragment() {
             }
         }
 
+    private lateinit var map: NaverMap
+    private val source: FusedLocationSource =
+        FusedLocationSource(this, LOCATION_PERMISSION_REQUEST_CODE)
+    private val requestPermissionLauncher =
+        registerForActivityResult(ActivityResultContracts.RequestPermission()) { isGranted ->
+            setLocationTrackingMode(isGranted)
+        }
+
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
@@ -43,6 +59,7 @@ class SaveLogFragment : Fragment() {
         super.onViewCreated(view, savedInstanceState)
         initAdapter()
         setAddImage()
+        loadMap()
     }
 
     override fun onDestroyView() {
@@ -58,5 +75,50 @@ class SaveLogFragment : Fragment() {
         binding.ibSelectPhoto.setOnClickListener {
             imageLauncher.launch(viewModel.getImage())
         }
+    }
+
+    private fun setLocationTrackingMode(isGranted: Boolean) {
+        map.locationTrackingMode =
+            if (isGranted) {
+                LocationTrackingMode.Follow
+            } else {
+                LocationTrackingMode.None
+            }
+    }
+
+    private fun initMap(naverMap: NaverMap) {
+        map = naverMap.apply {
+            locationSource = source
+            uiSettings.isZoomControlEnabled = false
+        }
+    }
+
+    private fun loadMap() {
+        val mapFragment = childFragmentManager.findFragmentById(R.id.fcv_map) as MapFragment
+        mapFragment.getMapAsync(this)
+    }
+
+    private fun handleLocationAccessPermission() {
+        when (PackageManager.PERMISSION_GRANTED) {
+            ContextCompat.checkSelfPermission(
+                requireContext(),
+                android.Manifest.permission.ACCESS_COARSE_LOCATION
+            ) -> {
+                setLocationTrackingMode(true)
+            }
+
+            else -> {
+                requestPermissionLauncher.launch(android.Manifest.permission.ACCESS_COARSE_LOCATION)
+            }
+        }
+    }
+
+    override fun onMapReady(naverMap: NaverMap) {
+        initMap(naverMap)
+        handleLocationAccessPermission()
+    }
+
+    companion object {
+        private const val LOCATION_PERMISSION_REQUEST_CODE = 1001
     }
 }

--- a/app/src/main/java/com/treasurehunt/ui/savelog/SaveLogMapFragment.kt
+++ b/app/src/main/java/com/treasurehunt/ui/savelog/SaveLogMapFragment.kt
@@ -1,0 +1,104 @@
+package com.treasurehunt.ui.savelog
+
+import android.content.pm.PackageManager
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.core.content.ContextCompat
+import androidx.fragment.app.Fragment
+import androidx.navigation.fragment.findNavController
+import com.naver.maps.map.LocationTrackingMode
+import com.naver.maps.map.MapFragment
+import com.naver.maps.map.NaverMap
+import com.naver.maps.map.OnMapReadyCallback
+import com.naver.maps.map.util.FusedLocationSource
+import com.treasurehunt.R
+import com.treasurehunt.databinding.FragmentSavelogMapBinding
+
+class SaveLogMapFragment : Fragment(), OnMapReadyCallback {
+
+    private var _binding: FragmentSavelogMapBinding? = null
+    private val binding get() = _binding!!
+
+    private lateinit var map: NaverMap
+    private val source: FusedLocationSource =
+        FusedLocationSource(this, LOCATION_PERMISSION_REQUEST_CODE)
+    private val requestPermissionLauncher =
+        registerForActivityResult(ActivityResultContracts.RequestPermission()) { isGranted ->
+            setLocationTrackingMode(isGranted)
+        }
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        _binding = FragmentSavelogMapBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        backScreen()
+        loadMap()
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+
+    private fun setLocationTrackingMode(isGranted: Boolean) {
+        map.locationTrackingMode =
+            if (isGranted) {
+                LocationTrackingMode.Follow
+            } else {
+                LocationTrackingMode.None
+            }
+    }
+
+    private fun backScreen() {
+        binding.mtbMapTitle.setNavigationOnClickListener {
+            findNavController().navigateUp()
+        }
+    }
+
+    private fun initMap(naverMap: NaverMap) {
+        map = naverMap.apply {
+            locationSource = source
+            uiSettings.isZoomControlEnabled = false
+            uiSettings.isLocationButtonEnabled = true
+        }
+    }
+
+    private fun loadMap() {
+        val mapFragment = childFragmentManager.findFragmentById(R.id.fcv_full_map) as MapFragment
+        mapFragment.getMapAsync(this)
+    }
+
+    private fun handleLocationAccessPermission() {
+        when (PackageManager.PERMISSION_GRANTED) {
+            ContextCompat.checkSelfPermission(
+                requireContext(),
+                android.Manifest.permission.ACCESS_COARSE_LOCATION
+            ) -> {
+                setLocationTrackingMode(true)
+            }
+
+            else -> {
+                requestPermissionLauncher.launch(android.Manifest.permission.ACCESS_COARSE_LOCATION)
+            }
+        }
+    }
+
+    override fun onMapReady(naverMap: NaverMap) {
+        initMap(naverMap)
+        handleLocationAccessPermission()
+    }
+
+    companion object {
+        private const val LOCATION_PERMISSION_REQUEST_CODE = 1002
+    }
+}

--- a/app/src/main/java/com/treasurehunt/ui/savelog/SaveLogViewModel.kt
+++ b/app/src/main/java/com/treasurehunt/ui/savelog/SaveLogViewModel.kt
@@ -44,7 +44,7 @@ class SaveLogViewModel : ViewModel() {
     }
 
     private fun setButtonState(): Boolean {
-        _isEnabled.value = _images.value.isNotEmpty() && _text.value?.isNotEmpty() == true
+        _isEnabled.value = _images.value.isNotEmpty() && _text.value.isNotEmpty()
         return _isEnabled.value
     }
 }

--- a/app/src/main/java/com/treasurehunt/ui/savelog/SaveLogViewModel.kt
+++ b/app/src/main/java/com/treasurehunt/ui/savelog/SaveLogViewModel.kt
@@ -14,8 +14,8 @@ class SaveLogViewModel : ViewModel() {
     val images = _images.asStateFlow()
     private val _isImageMax = MutableStateFlow(false)
     val isImageMax = _isImageMax.asStateFlow()
-    private val _text: MutableLiveData<String> = MutableLiveData()
-    val text: LiveData<String> = _text
+    private val _text: MutableStateFlow<String> = MutableStateFlow("")
+    val text = _text.asStateFlow()
     private val _isEnabled: MutableStateFlow<Boolean> = MutableStateFlow(false)
     val isEnabled = _isEnabled.asStateFlow()
 

--- a/app/src/main/java/com/treasurehunt/ui/savelog/SaveLogViewModel.kt
+++ b/app/src/main/java/com/treasurehunt/ui/savelog/SaveLogViewModel.kt
@@ -1,13 +1,12 @@
-package com.treasurehunt.ui.login
+package com.treasurehunt.ui.savelog
 
 import android.content.Intent
 import android.provider.MediaStore
 import androidx.lifecycle.ViewModel
-import com.treasurehunt.ui.savelog.ImageModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 
-class LogViewModel : ViewModel() {
+class SaveLogViewModel : ViewModel() {
 
     private val _images: MutableStateFlow<List<ImageModel>> = MutableStateFlow(emptyList())
     val images = _images.asStateFlow()

--- a/app/src/main/java/com/treasurehunt/ui/savelog/SaveLogViewModel.kt
+++ b/app/src/main/java/com/treasurehunt/ui/savelog/SaveLogViewModel.kt
@@ -27,13 +27,13 @@ class SaveLogViewModel : ViewModel() {
     }
 
     fun addImage(image: ImageModel) {
-        _images.value = images.value + image
+        _images.value += image
         _isImageMax.value = images.value.size >= 5
         setButtonState()
     }
 
     fun removeImage(image: ImageModel) {
-        _images.value = images.value - image
+        _images.value -= image
         _isImageMax.value = images.value.size >= 5
         setButtonState()
     }

--- a/app/src/main/java/com/treasurehunt/ui/savelog/SaveLogViewModel.kt
+++ b/app/src/main/java/com/treasurehunt/ui/savelog/SaveLogViewModel.kt
@@ -29,21 +29,21 @@ class SaveLogViewModel : ViewModel() {
     fun addImage(image: ImageModel) {
         _images.value = images.value + image
         _isImageMax.value = images.value.size >= 5
-        validateButtonState()
+        setButtonState()
     }
 
     fun removeImage(image: ImageModel) {
         _images.value = images.value - image
         _isImageMax.value = images.value.size >= 5
-        validateButtonState()
+        setButtonState()
     }
 
     fun setTextInput(input: CharSequence) {
         _text.value = input.toString()
-        validateButtonState()
+        setButtonState()
     }
 
-    private fun validateButtonState(): Boolean {
+    private fun setButtonState(): Boolean {
         _isEnabled.value = _images.value.isNotEmpty() && _text.value?.isNotEmpty() == true
         return _isEnabled.value
     }

--- a/app/src/main/java/com/treasurehunt/ui/savelog/SaveLogViewModel.kt
+++ b/app/src/main/java/com/treasurehunt/ui/savelog/SaveLogViewModel.kt
@@ -2,6 +2,8 @@ package com.treasurehunt.ui.savelog
 
 import android.content.Intent
 import android.provider.MediaStore
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -12,6 +14,10 @@ class SaveLogViewModel : ViewModel() {
     val images = _images.asStateFlow()
     private val _isImageMax = MutableStateFlow(false)
     val isImageMax = _isImageMax.asStateFlow()
+    private val _text: MutableLiveData<String> = MutableLiveData()
+    val text: LiveData<String> = _text
+    private val _isEnabled: MutableStateFlow<Boolean> = MutableStateFlow(false)
+    val isEnabled = _isEnabled.asStateFlow()
 
     fun getImage(): Intent {
         return Intent(Intent.ACTION_PICK, MediaStore.Images.Media.EXTERNAL_CONTENT_URI).apply {
@@ -23,10 +29,22 @@ class SaveLogViewModel : ViewModel() {
     fun addImage(image: ImageModel) {
         _images.value = images.value + image
         _isImageMax.value = images.value.size >= 5
+        validateButtonState()
     }
 
     fun removeImage(image: ImageModel) {
         _images.value = images.value - image
         _isImageMax.value = images.value.size >= 5
+        validateButtonState()
+    }
+
+    fun setTextInput(input: CharSequence) {
+        _text.value = input.toString()
+        validateButtonState()
+    }
+
+    private fun validateButtonState(): Boolean {
+        _isEnabled.value = _images.value.isNotEmpty() && _text.value?.isNotEmpty() == true
+        return _isEnabled.value
     }
 }

--- a/app/src/main/java/com/treasurehunt/ui/savelog/SaveLogViewModel.kt
+++ b/app/src/main/java/com/treasurehunt/ui/savelog/SaveLogViewModel.kt
@@ -2,8 +2,6 @@ package com.treasurehunt.ui.savelog
 
 import android.content.Intent
 import android.provider.MediaStore
-import androidx.lifecycle.LiveData
-import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow

--- a/app/src/main/java/com/treasurehunt/ui/savelog/adapter/SaveLogAdapter.kt
+++ b/app/src/main/java/com/treasurehunt/ui/savelog/adapter/SaveLogAdapter.kt
@@ -5,12 +5,12 @@ import android.view.ViewGroup
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
-import com.treasurehunt.databinding.ItemLogBinding
+import com.treasurehunt.databinding.ItemSavelogBinding
 import com.treasurehunt.ui.savelog.ImageClickListener
 import com.treasurehunt.ui.savelog.ImageModel
 
-class LogAdapter(private val clickListener: ImageClickListener) :
-    ListAdapter<ImageModel, LogAdapter.ViewHolder>(diffUtil) {
+class SaveLogAdapter(private val clickListener: ImageClickListener) :
+    ListAdapter<ImageModel, SaveLogAdapter.ViewHolder>(diffUtil) {
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
         return ViewHolder.from(parent)
     }
@@ -19,7 +19,7 @@ class LogAdapter(private val clickListener: ImageClickListener) :
         holder.bind(getItem(position), clickListener)
     }
 
-    class ViewHolder(private val binding: ItemLogBinding) :
+    class ViewHolder(private val binding: ItemSavelogBinding) :
         RecyclerView.ViewHolder(binding.root) {
         fun bind(imageModel: ImageModel, clickListener: ImageClickListener) {
             binding.imageModel = imageModel
@@ -30,7 +30,7 @@ class LogAdapter(private val clickListener: ImageClickListener) :
         companion object {
             fun from(parent: ViewGroup): ViewHolder {
                 return ViewHolder(
-                    ItemLogBinding.inflate(
+                    ItemSavelogBinding.inflate(
                         LayoutInflater.from(parent.context),
                         parent,
                         false

--- a/app/src/main/java/com/treasurehunt/util/Extensions.kt
+++ b/app/src/main/java/com/treasurehunt/util/Extensions.kt
@@ -1,0 +1,12 @@
+package com.treasurehunt.util
+
+import android.view.View
+import com.google.android.material.snackbar.Snackbar
+
+fun View.showSnackbar(resId: Int) {
+    Snackbar.make(
+        this,
+        resId,
+        Snackbar.LENGTH_SHORT
+    ).show()
+}

--- a/app/src/main/res/drawable/ic_full_screen.xml
+++ b/app/src/main/res/drawable/ic_full_screen.xml
@@ -1,0 +1,16 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="32dp"
+    android:height="32dp"
+    android:viewportWidth="32"
+    android:viewportHeight="32">
+  <path
+      android:pathData="M16,16m-16,0a16,16 0,1 1,32 0a16,16 0,1 1,-32 0"
+      android:fillColor="#ffffff"/>
+  <group>
+    <clip-path
+        android:pathData="M8,8h16v16h-16z"/>
+    <path
+        android:pathData="M18,10L19.533,11.533L17.607,13.447L18.553,14.393L20.467,12.467L22,14V10H18ZM10,14L11.533,12.467L13.447,14.393L14.393,13.447L12.467,11.533L14,10H10V14ZM14,22L12.467,20.467L14.393,18.553L13.447,17.607L11.533,19.533L10,18V22H14ZM22,18L20.467,19.533L18.553,17.607L17.607,18.553L19.533,20.467L18,22H22V18Z"
+        android:fillColor="#BDBDBD"/>
+  </group>
+</vector>

--- a/app/src/main/res/layout/activity_home.xml
+++ b/app/src/main/res/layout/activity_home.xml
@@ -4,7 +4,6 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="@drawable/background"
     tools:context=".ui.home.HomeActivity">
 
     <androidx.fragment.app.FragmentContainerView

--- a/app/src/main/res/layout/fragment_savelog.xml
+++ b/app/src/main/res/layout/fragment_savelog.xml
@@ -27,7 +27,7 @@
                 android:layout_marginStart="16dp"
                 android:layout_marginTop="40dp"
                 android:background="@android:color/transparent"
-                android:contentDescription="@string/log_ib_cancel"
+                android:contentDescription="@string/savelog_ib_cancel"
                 android:src="@drawable/icon_cancel"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toTopOf="parent" />
@@ -38,7 +38,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="40dp"
-                android:text="@string/log_tv_title"
+                android:text="@string/savelog_tv_title"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toTopOf="parent" />
@@ -61,7 +61,7 @@
                 android:layout_height="wrap_content"
                 android:layout_marginStart="16dp"
                 android:layout_marginTop="16dp"
-                android:text="@{@string/log_tv_photo_count(viewModel.images.size())}"
+                android:text="@{@string/savelog_tv_photo_count(viewModel.images.size())}"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@id/fcv_map" />
 
@@ -96,7 +96,7 @@
                 android:layout_height="wrap_content"
                 android:layout_marginStart="16dp"
                 android:layout_marginTop="16dp"
-                android:text="@string/log_tv_text"
+                android:text="@string/savelog_tv_text"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@id/ib_select_photo" />
 
@@ -121,7 +121,7 @@
                 android:layout_height="52dp"
                 android:layout_marginHorizontal="16dp"
 
-                android:text="@string/log_btn_save"
+                android:text="@string/savelog_btn_save"
                 app:cornerRadius="12dp"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"

--- a/app/src/main/res/layout/fragment_savelog.xml
+++ b/app/src/main/res/layout/fragment_savelog.xml
@@ -82,11 +82,11 @@
                 android:layout_height="wrap_content"
                 android:layout_marginStart="4dp"
                 android:orientation="horizontal"
+                app:dataset="@{viewModel.images}"
                 app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toEndOf="@+id/ib_select_photo"
                 app:layout_constraintTop_toTopOf="@+id/ib_select_photo"
-                app:dataset="@{viewModel.images}"
                 tools:listitem="@layout/item_savelog" />
 
             <TextView
@@ -107,8 +107,10 @@
                 android:layout_height="130dp"
                 android:layout_marginHorizontal="16dp"
                 android:layout_marginTop="16dp"
+                android:onTextChanged="@{ (s, start, before, count) -> viewModel.setTextInput(s) }"
                 android:paddingStart="16dp"
                 android:paddingTop="16dp"
+                android:text="@{viewModel.text}"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@id/tv_text"
@@ -120,7 +122,7 @@
                 android:layout_width="0dp"
                 android:layout_height="52dp"
                 android:layout_marginHorizontal="16dp"
-
+                android:enabled="@{viewModel.isEnabled}"
                 android:text="@string/savelog_btn_save"
                 app:cornerRadius="12dp"
                 app:layout_constraintBottom_toBottomOf="parent"

--- a/app/src/main/res/layout/fragment_savelog.xml
+++ b/app/src/main/res/layout/fragment_savelog.xml
@@ -7,7 +7,7 @@
 
         <variable
             name="viewModel"
-            type="com.treasurehunt.ui.login.LogViewModel" />
+            type="com.treasurehunt.ui.savelog.SaveLogViewModel" />
     </data>
 
     <androidx.core.widget.NestedScrollView
@@ -34,7 +34,7 @@
 
             <TextView
                 android:id="@+id/tv_title"
-                style="@style/LogTitle"
+                style="@style/SaveLogTitle"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="40dp"
@@ -58,7 +58,7 @@
 
             <TextView
                 android:id="@+id/tv_photo"
-                style="@style/LogPhoto"
+                style="@style/SaveLogPhoto"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginStart="16dp"
@@ -89,11 +89,11 @@
                 app:layout_constraintStart_toEndOf="@+id/ib_select_photo"
                 app:layout_constraintTop_toTopOf="@+id/ib_select_photo"
                 app:dataset="@{viewModel.images}"
-                tools:listitem="@layout/item_log" />
+                tools:listitem="@layout/item_savelog" />
 
             <TextView
                 android:id="@+id/tv_text"
-                style="@style/LogPhoto"
+                style="@style/SaveLogPhoto"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginStart="16dp"
@@ -104,7 +104,7 @@
 
             <EditText
                 android:id="@+id/et_text"
-                style="@style/Font.LogText"
+                style="@style/Font.SaveLogText"
                 android:layout_width="0dp"
                 android:layout_height="130dp"
                 android:layout_marginHorizontal="16dp"
@@ -118,7 +118,7 @@
 
             <Button
                 android:id="@+id/btn_save"
-                style="@style/Font.LogSave"
+                style="@style/Font.SaveLogSave"
                 android:layout_width="0dp"
                 android:layout_height="52dp"
                 android:layout_marginHorizontal="16dp"

--- a/app/src/main/res/layout/fragment_savelog.xml
+++ b/app/src/main/res/layout/fragment_savelog.xml
@@ -54,6 +54,17 @@
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@id/tv_title" />
 
+            <ImageButton
+                android:id="@+id/ib_full_screen"
+                android:layout_width="32dp"
+                android:layout_height="32dp"
+                android:layout_marginEnd="4dp"
+                android:layout_marginBottom="4dp"
+                android:backgroundTint="@android:color/transparent"
+                android:src="@drawable/ic_full_screen"
+                app:layout_constraintBottom_toBottomOf="@+id/fcv_map"
+                app:layout_constraintEnd_toEndOf="@+id/fcv_map" />
+
             <TextView
                 android:id="@+id/tv_photo"
                 style="@style/SaveLogPhoto"

--- a/app/src/main/res/layout/fragment_savelog.xml
+++ b/app/src/main/res/layout/fragment_savelog.xml
@@ -43,15 +43,13 @@
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toTopOf="parent" />
 
-            <!-- map 표시될 view -->
-            <com.google.android.material.card.MaterialCardView
-                android:id="@+id/mcv_map"
+            <androidx.fragment.app.FragmentContainerView
+                android:id="@+id/fcv_map"
+                android:name="com.naver.maps.map.MapFragment"
                 android:layout_width="0dp"
                 android:layout_height="130dp"
                 android:layout_marginHorizontal="16dp"
                 android:layout_marginTop="16dp"
-                android:background="@drawable/button_record"
-                app:cardCornerRadius="20dp"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@id/tv_title" />
@@ -65,7 +63,7 @@
                 android:layout_marginTop="16dp"
                 android:text="@string/log_tv_photo"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/mcv_map" />
+                app:layout_constraintTop_toBottomOf="@id/fcv_map" />
 
             <ImageButton
                 android:id="@+id/ib_select_photo"
@@ -122,7 +120,7 @@
                 android:layout_width="0dp"
                 android:layout_height="52dp"
                 android:layout_marginHorizontal="16dp"
-                android:enabled="false"
+
                 android:text="@string/log_btn_save"
                 app:cornerRadius="12dp"
                 app:layout_constraintBottom_toBottomOf="parent"

--- a/app/src/main/res/layout/fragment_savelog.xml
+++ b/app/src/main/res/layout/fragment_savelog.xml
@@ -61,7 +61,7 @@
                 android:layout_height="wrap_content"
                 android:layout_marginStart="16dp"
                 android:layout_marginTop="16dp"
-                android:text="@string/log_tv_photo"
+                android:text="@{@string/log_tv_photo_count(viewModel.images.size())}"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@id/fcv_map" />
 

--- a/app/src/main/res/layout/fragment_savelog_map.xml
+++ b/app/src/main/res/layout/fragment_savelog_map.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/mtb_map_title"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:navigationIcon="@drawable/icon_cancel"
+        app:title="지도 보기"
+        app:titleCentered="true"
+        app:titleTextAppearance="@style/Font.SaveLogMapTitle" />
+
+    <androidx.fragment.app.FragmentContainerView
+        android:id="@+id/fcv_full_map"
+        android:name="com.naver.maps.map.MapFragment"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/mtb_map_title" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/item_savelog.xml
+++ b/app/src/main/res/layout/item_savelog.xml
@@ -28,7 +28,7 @@
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
-            app:shapeAppearance="@style/LogImage" />
+            app:shapeAppearance="@style/SaveLogImage" />
 
         <ImageView
             android:id="@+id/iv_delete"

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -9,7 +9,7 @@
         android:id="@+id/splashFragment"
         android:name="com.treasurehunt.ui.login.SplashFragment"
         android:label="fragment_splash"
-        tools:layout="@layout/fragment_splash" >
+        tools:layout="@layout/fragment_splash">
         <action
             android:id="@+id/action_splashFragment_to_logInFragment"
             app:destination="@id/logInFragment" />
@@ -19,11 +19,21 @@
         android:id="@+id/logInFragment"
         android:name="com.treasurehunt.ui.login.LogInFragment"
         android:label="fragment_login"
-        tools:layout="@layout/fragment_login" />
+        tools:layout="@layout/fragment_login">
+        <action
+            android:id="@+id/action_logInFragment_to_saveLogFragment"
+            app:destination="@id/saveLogFragment" />
+    </fragment>
 
     <fragment
         android:id="@+id/homeFragment"
         android:name="com.treasurehunt.ui.home.HomeFragment"
         android:label="fragment_home"
         tools:layout="@layout/fragment_home" />
+
+    <fragment
+        android:id="@+id/saveLogFragment"
+        android:name="com.treasurehunt.ui.savelog.SaveLogFragment"
+        android:label="SaveLogFragment"
+        tools:layout="@layout/fragment_savelog" />
 </navigation>

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -35,5 +35,15 @@
         android:id="@+id/saveLogFragment"
         android:name="com.treasurehunt.ui.savelog.SaveLogFragment"
         android:label="SaveLogFragment"
-        tools:layout="@layout/fragment_savelog" />
+        tools:layout="@layout/fragment_savelog">
+        <action
+            android:id="@+id/action_saveLogFragment_to_saveLogMapFragment"
+            app:destination="@id/saveLogMapFragment" />
+    </fragment>
+
+    <fragment
+        android:id="@+id/saveLogMapFragment"
+        android:name="com.treasurehunt.ui.savelog.SaveLogMapFragment"
+        android:label="SaveLogMapFragment"
+        tools:layout="@layout/fragment_savelog_map" />
 </navigation>

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -20,9 +20,6 @@
         android:name="com.treasurehunt.ui.login.LogInFragment"
         android:label="fragment_login"
         tools:layout="@layout/fragment_login">
-        <action
-            android:id="@+id/action_logInFragment_to_saveLogFragment"
-            app:destination="@id/saveLogFragment" />
     </fragment>
 
     <fragment

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -15,11 +15,11 @@
     <string name="login_treasure_hunt">보물찾기</string>
 
     <!-- 기록 저장 화면 -->
-    <string name="log_tv_title">내 추억</string>
-    <string name="log_ib_cancel">작성 중인 글을 취소하는 버튼입니다.</string>
-    <string name="log_tv_text">글</string>
-    <string name="log_tv_photo">사진 (0/5)</string>
-    <string name="log_tv_photo_count">사진 (%1$d/5)</string>
-    <string name="log_btn_save">등록</string>
-    <string name="log_sb_warning_count">사진은 5개까지만 등록 가능합니다.</string>
+    <string name="savelog_tv_title">내 추억</string>
+    <string name="savelog_ib_cancel">작성 중인 글을 취소하는 버튼입니다.</string>
+    <string name="savelog_tv_text">글</string>
+    <string name="savelog_tv_photo">사진 (0/5)</string>
+    <string name="savelog_tv_photo_count">사진 (%1$d/5)</string>
+    <string name="savelog_btn_save">등록</string>
+    <string name="savelog_sb_warning_count">사진은 5개까지만 등록 가능합니다.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -22,4 +22,6 @@
     <string name="savelog_tv_photo_count">사진 (%1$d/5)</string>
     <string name="savelog_btn_save">등록</string>
     <string name="savelog_sb_warning_count">사진은 5개까지만 등록 가능합니다.</string>
+    <string name="savelog_sb_upload_success">사진 업로드 성공</string>
+    <string name="savelog_sb_upload_failure">사진 업로드 실패</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -19,5 +19,7 @@
     <string name="log_ib_cancel">작성 중인 글을 취소하는 버튼입니다.</string>
     <string name="log_tv_text">글</string>
     <string name="log_tv_photo">사진 (0/5)</string>
+    <string name="log_tv_photo_count">사진 (%1$d/5)</string>
     <string name="log_btn_save">등록</string>
+    <string name="log_sb_warning_count">사진은 5개까지만 등록 가능합니다.</string>
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -67,4 +67,10 @@
     <style name="SaveLogImage">
         <item name="cornerSize">12dp</item>
     </style>
+
+    <!-- 지도 전체 화면 -->
+    <style name="Font.SaveLogMapTitle">
+        <item name="android:textColor">@color/black</item>
+        <item name="android:textSize">@dimen/xLarge</item>
+    </style>
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -38,33 +38,33 @@
     </style>
 
     <!--기록 저장 화면 -->
-    <style name="LogTitle">
+    <style name="SaveLogTitle">
         <item name="android:fontFamily">@font/pretendard_semibold</item>
         <item name="android:textColor">@color/black</item>
         <item name="android:textSize">@dimen/large</item>
     </style>
 
-    <style name="LogPhoto">
+    <style name="SaveLogPhoto">
         <item name="android:fontFamily">@font/pretendard_semibold</item>
         <item name="android:textColor">@color/black</item>
         <item name="android:textSize">@dimen/middle</item>
     </style>
 
-    <style name="Font.LogText">
+    <style name="Font.SaveLogText">
         <item name="android:background">@drawable/button_record</item>
         <item name="android:gravity">top|start</item>
         <item name="android:textColor">@color/black</item>
         <item name="android:textSize">14sp</item>
     </style>
 
-    <style name="Font.LogSave">
+    <style name="Font.SaveLogSave">
         <item name="android:backgroundTint">@drawable/selector_button_record_background</item>
         <item name="android:textColor">@drawable/selector_button_record_text_color</item>
         <item name="android:textStyle">bold</item>
         <item name="android:textSize">@dimen/middle</item>
     </style>
 
-    <style name="LogImage">
+    <style name="SaveLogImage">
         <item name="cornerSize">12dp</item>
     </style>
 </resources>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,3 +4,9 @@ plugins {
     id("org.jetbrains.kotlin.android") version "1.9.0" apply false
     id("com.google.gms.google-services") version "4.4.0" apply false
 }
+
+buildscript {
+    dependencies {
+        classpath("org.jetbrains.kotlin:kotlin-serialization:1.9.0")
+    }
+}


### PR DESCRIPTION
구현사항
- 지도 스냅샷 표시
- 지도 스냅샷에 전체 화면 아이콘을 누르면 전체화면으로 보여주는 기능 구현
- 선택한 사진의 수가 텍스트에 뜨도록 구현
- 선택 가능한 사진의 수를 5개로 제한하는 예외처리 구현
- 기록 저장 구현
  - 사진은 Firebase Cloud Storage에 저장되도록 구현
  - Firebase Realtime Database에 나머지 Logs에 있는 내용 저장
- 로컬 db는 병합 후 구현 예정

피드백 반영
- 함수 및 변수 이름 변경
- imageLauncher 함수 분리
- 하드 코딩 되어있는 부분 const 변수로 변경
- livedata -> stateFlow 변경
- 검사 조건 직관적으로 보이도록 수정
- 테스트 코드 삭제