### PR TITLE
[홈 지도 화면 및 기록 저장 화면] 지도상에 장소와 마커 클릭 기능 구현 및 기록 저장 확인 버튼 클릭시 로컬과 원격 DB에 연동

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -7,6 +7,8 @@ plugins {
     kotlin("kapt")
     id("com.google.devtools.ksp")
     id("org.jetbrains.kotlin.plugin.serialization")
+    id("androidx.navigation.safeargs.kotlin")
+    id("kotlin-parcelize")
 }
 
 android {

--- a/app/src/main/java/com/treasurehunt/data/LogRepository.kt
+++ b/app/src/main/java/com/treasurehunt/data/LogRepository.kt
@@ -8,7 +8,7 @@ interface LogRepository {
 
     suspend fun insert(log: LogEntity): Long
 
-    suspend fun insert(log: LogDTO)
+    suspend fun insert(log: LogDTO): String
 
     suspend fun getRemoteLog(id: String): LogDTO
 

--- a/app/src/main/java/com/treasurehunt/data/LogRepositoryImpl.kt
+++ b/app/src/main/java/com/treasurehunt/data/LogRepositoryImpl.kt
@@ -12,12 +12,12 @@ class LogRepositoryImpl(
 ) : LogRepository {
 
     override suspend fun insert(log: LogEntity) = logDao.insert(log)
-    override suspend fun getRemoteLog(id: String): LogDTO = logRemoteDataSource.getLog(id)
-    override suspend fun getRemoteAllLogs(): List<LogDTO> = logRemoteDataSource.getAllLogs()
 
-    override suspend fun insert(logDTD: LogDTO) {
-        logRemoteDataSource.insert(logDTD)
-    }
+    override suspend fun insert(logDTD: LogDTO) = logRemoteDataSource.insert(logDTD).name
+
+    override suspend fun getRemoteLog(id: String): LogDTO = logRemoteDataSource.getLog(id)
+
+    override suspend fun getRemoteAllLogs(): List<LogDTO> = logRemoteDataSource.getAllLogs()
 
     override fun getLogById(id: String): Flow<LogEntity> = logDao.getLogById(id)
 
@@ -26,8 +26,8 @@ class LogRepositoryImpl(
     override fun update(log: LogEntity) = logDao.update(log)
 
     override suspend fun delete(vararg logs: LogEntity) = logDao.delete(*logs)
+
     override suspend fun deleteAll() {
         logDao.deleteAllLogs()
     }
-
 }

--- a/app/src/main/java/com/treasurehunt/data/PlaceRepository.kt
+++ b/app/src/main/java/com/treasurehunt/data/PlaceRepository.kt
@@ -8,6 +8,8 @@ interface PlaceRepository {
 
     suspend fun insert(place: PlaceEntity): Long
 
+    suspend fun insert(place: PlaceDTO): String
+
     suspend fun getRemotePlace(id: String): PlaceDTO
 
     fun getPlaceById(id: String): Flow<PlaceEntity>

--- a/app/src/main/java/com/treasurehunt/data/PlaceRepository.kt
+++ b/app/src/main/java/com/treasurehunt/data/PlaceRepository.kt
@@ -18,7 +18,7 @@ interface PlaceRepository {
 
     fun getAllPlans(): Flow<List<PlaceEntity>>
 
-    fun update(place: PlaceEntity): Int
+    suspend fun update(place: PlaceEntity): Int
 
     suspend fun delete(vararg places: PlaceEntity): Int
 

--- a/app/src/main/java/com/treasurehunt/data/PlaceRepository.kt
+++ b/app/src/main/java/com/treasurehunt/data/PlaceRepository.kt
@@ -20,6 +20,8 @@ interface PlaceRepository {
 
     suspend fun update(place: PlaceEntity): Int
 
+    suspend fun update(id: String, placeDTO: PlaceDTO)
+
     suspend fun delete(vararg places: PlaceEntity): Int
 
     suspend fun deleteAll()

--- a/app/src/main/java/com/treasurehunt/data/PlaceRepositoryImpl.kt
+++ b/app/src/main/java/com/treasurehunt/data/PlaceRepositoryImpl.kt
@@ -25,6 +25,10 @@ class PlaceRepositoryImpl(
 
     override suspend fun update(place: PlaceEntity) = placeDao.update(place)
 
+    override suspend fun update(id: String, placeDTO: PlaceDTO) {
+        placeRemoteDataSource.update(id, placeDTO)
+    }
+
     override suspend fun delete(vararg places: PlaceEntity) = placeDao.delete(*places)
 
     override suspend fun deleteAll() {

--- a/app/src/main/java/com/treasurehunt/data/PlaceRepositoryImpl.kt
+++ b/app/src/main/java/com/treasurehunt/data/PlaceRepositoryImpl.kt
@@ -12,6 +12,9 @@ class PlaceRepositoryImpl(
 ) : PlaceRepository {
 
     override suspend fun insert(place: PlaceEntity) = placeDao.insert(place)
+
+    override suspend fun insert(place: PlaceDTO): String = placeRemoteDataSource.insert(place)
+
     override suspend fun getRemotePlace(id: String): PlaceDTO = placeRemoteDataSource.getPlace(id)
 
     override fun getPlaceById(id: String): Flow<PlaceEntity> = placeDao.getPlaceById(id)

--- a/app/src/main/java/com/treasurehunt/data/PlaceRepositoryImpl.kt
+++ b/app/src/main/java/com/treasurehunt/data/PlaceRepositoryImpl.kt
@@ -23,7 +23,7 @@ class PlaceRepositoryImpl(
 
     override fun getAllPlans(): Flow<List<PlaceEntity>> = placeDao.getAllPlans()
 
-    override fun update(place: PlaceEntity) = placeDao.update(place)
+    override suspend fun update(place: PlaceEntity) = placeDao.update(place)
 
     override suspend fun delete(vararg places: PlaceEntity) = placeDao.delete(*places)
 

--- a/app/src/main/java/com/treasurehunt/data/UserRepository.kt
+++ b/app/src/main/java/com/treasurehunt/data/UserRepository.kt
@@ -17,5 +17,7 @@ interface UserRepository {
     fun update(user: UserEntity): Int
     suspend fun update(id: String, data: UserDTO)
 
+    suspend fun update(uid: String, user: UserDTO)
+
     suspend fun delete(vararg users: UserEntity): Int
 }

--- a/app/src/main/java/com/treasurehunt/data/UserRepository.kt
+++ b/app/src/main/java/com/treasurehunt/data/UserRepository.kt
@@ -15,9 +15,8 @@ interface UserRepository {
     fun getAllUsers(): Flow<List<UserEntity>>
 
     fun update(user: UserEntity): Int
-    suspend fun update(id: String, data: UserDTO)
 
-    suspend fun update(uid: String, user: UserDTO)
+    suspend fun update(id: String, data: UserDTO)
 
     suspend fun delete(vararg users: UserEntity): Int
 }

--- a/app/src/main/java/com/treasurehunt/data/local/PlaceDao.kt
+++ b/app/src/main/java/com/treasurehunt/data/local/PlaceDao.kt
@@ -25,7 +25,7 @@ interface PlaceDao {
     fun getAllPlans(): Flow<List<PlaceEntity>>
 
     @Update
-    fun update(place: PlaceEntity): Int
+    suspend fun update(place: PlaceEntity): Int
 
     @Delete
     suspend fun delete(vararg places: PlaceEntity): Int

--- a/app/src/main/java/com/treasurehunt/data/local/model/LogEntity.kt
+++ b/app/src/main/java/com/treasurehunt/data/local/model/LogEntity.kt
@@ -21,5 +21,5 @@ data class LogEntity(
 
 fun LogEntity.toLogDTO(): LogDTO {
     val (place, images, text, theme, createdDate) = this
-    return LogDTO(place, images, text, theme, createdDate)
+    return LogDTO(place, images.associateWith { true }, text, theme, createdDate)
 }

--- a/app/src/main/java/com/treasurehunt/data/local/model/LogEntity.kt
+++ b/app/src/main/java/com/treasurehunt/data/local/model/LogEntity.kt
@@ -3,6 +3,7 @@ package com.treasurehunt.data.local.model
 import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.PrimaryKey
+import com.treasurehunt.data.remote.model.LogDTO
 
 @Entity(tableName = "logs")
 data class LogEntity(
@@ -17,3 +18,8 @@ data class LogEntity(
     @PrimaryKey(autoGenerate = true)
     val id: Long = 0
 )
+
+fun LogEntity.toLogDTO(): LogDTO {
+    val (place, images, text, theme, createdDate) = this
+    return LogDTO(place, images, text, theme, createdDate)
+}

--- a/app/src/main/java/com/treasurehunt/data/local/model/PlaceEntity.kt
+++ b/app/src/main/java/com/treasurehunt/data/local/model/PlaceEntity.kt
@@ -3,6 +3,7 @@ package com.treasurehunt.data.local.model
 import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.PrimaryKey
+import com.treasurehunt.data.remote.model.PlaceDTO
 
 @Entity("places")
 data class PlaceEntity(
@@ -10,9 +11,14 @@ data class PlaceEntity(
     val lng: Double,
     val plan: Boolean,
     val caption: String,
+    val log: String? = null,
     @ColumnInfo("remote_id")
     val remoteId: String? = null,
-    val log: String? = null,
     @PrimaryKey(autoGenerate = true)
     val id: Long = 0
 )
+
+fun PlaceEntity.toPlaceDTO(): PlaceDTO {
+    val (lat, lng, plan, caption, log, remoteId, id) = this
+    return PlaceDTO(lat, lng, plan, caption, log, remoteId, id)
+}

--- a/app/src/main/java/com/treasurehunt/data/remote/LogService.kt
+++ b/app/src/main/java/com/treasurehunt/data/remote/LogService.kt
@@ -3,6 +3,7 @@ package com.treasurehunt.data.remote
 import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFactory
 import com.treasurehunt.BuildConfig
 import com.treasurehunt.data.remote.model.LogDTO
+import com.treasurehunt.data.remote.model.RemoteIdWrapper
 import kotlinx.serialization.json.Json
 import okhttp3.MediaType.Companion.toMediaType
 import retrofit2.Retrofit
@@ -29,7 +30,7 @@ interface LogService {
     suspend fun getAllLogs(): List<LogDTO>
 
     @POST("logs.json")
-    suspend fun insert(@Body logDTO: LogDTO)
+    suspend fun insert(@Body logDTO: LogDTO): RemoteIdWrapper
 
     companion object {
 

--- a/app/src/main/java/com/treasurehunt/data/remote/PlaceService.kt
+++ b/app/src/main/java/com/treasurehunt/data/remote/PlaceService.kt
@@ -4,12 +4,14 @@ import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFact
 import com.treasurehunt.BuildConfig
 import com.treasurehunt.data.remote.model.PlaceDTO
 import com.treasurehunt.data.remote.model.RemoteIdWrapper
+import com.treasurehunt.data.remote.model.UserDTO
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import okhttp3.MediaType.Companion.toMediaType
 import retrofit2.Retrofit
 import retrofit2.http.Body
 import retrofit2.http.GET
+import retrofit2.http.PATCH
 import retrofit2.http.POST
 import retrofit2.http.Path
 
@@ -30,6 +32,12 @@ interface PlaceService {
     suspend fun getPlace(
         @Path("id") id: String
     ): PlaceDTO
+
+    @PATCH("/places/{id}.json")
+    suspend fun update(
+        @Path("id") id: String,
+        @Body data: PlaceDTO
+    )
 
     companion object {
 

--- a/app/src/main/java/com/treasurehunt/data/remote/PlaceService.kt
+++ b/app/src/main/java/com/treasurehunt/data/remote/PlaceService.kt
@@ -3,10 +3,14 @@ package com.treasurehunt.data.remote
 import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFactory
 import com.treasurehunt.BuildConfig
 import com.treasurehunt.data.remote.model.PlaceDTO
+import com.treasurehunt.data.remote.model.RemoteIdWrapper
+import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import okhttp3.MediaType.Companion.toMediaType
 import retrofit2.Retrofit
+import retrofit2.http.Body
 import retrofit2.http.GET
+import retrofit2.http.POST
 import retrofit2.http.Path
 
 
@@ -18,6 +22,9 @@ private val jsonRule = Json {
 }
 
 interface PlaceService {
+
+    @POST("places.json")
+    suspend fun insert(@Body placeDTO: PlaceDTO): RemoteIdWrapper
 
     @GET("/places/{id}.json")
     suspend fun getPlace(

--- a/app/src/main/java/com/treasurehunt/data/remote/UserService.kt
+++ b/app/src/main/java/com/treasurehunt/data/remote/UserService.kt
@@ -27,16 +27,16 @@ interface UserService {
         @Body userDTO: UserDTO
     )
 
+    @GET("/users/{id}.json")
+    suspend fun getUser(
+        @Path("id") id: String
+    ): UserDTO
+
     @PATCH("/users/{id}.json")
     suspend fun update(
         @Path("id") id: String,
         @Body userDTO: UserDTO
     )
-
-    @GET("/users/{id}.json")
-    suspend fun getUser(
-        @Path("id") id: String
-    ): UserDTO
 
     companion object {
 

--- a/app/src/main/java/com/treasurehunt/data/remote/model/MapUiState.kt
+++ b/app/src/main/java/com/treasurehunt/data/remote/model/MapUiState.kt
@@ -4,7 +4,7 @@ import com.naver.maps.map.overlay.Marker
 import com.treasurehunt.data.local.model.PlaceEntity
 
 data class MapUiState(
-    val isSignedInAsMember: Boolean = false,
+    val uid: String? = null,
     val visits: List<PlaceEntity> = listOf(),
     val plans: List<PlaceEntity> = listOf(),
     val visitMarkers: List<Marker> = listOf(),

--- a/app/src/main/java/com/treasurehunt/data/remote/model/MapUiState.kt
+++ b/app/src/main/java/com/treasurehunt/data/remote/model/MapUiState.kt
@@ -5,8 +5,9 @@ import com.treasurehunt.data.local.model.PlaceEntity
 
 data class MapUiState(
     val isSignedInAsMember: Boolean = false,
-    val places: List<PlaceEntity> = listOf(),
+    val visits: List<PlaceEntity> = listOf(),
     val plans: List<PlaceEntity> = listOf(),
-    val markers: List<Marker> = listOf(),
+    val visitMarkers: List<Marker> = listOf(),
+    val planMarkers: List<Marker> = listOf(),
     val isOnline: Boolean = false
 )

--- a/app/src/main/java/com/treasurehunt/data/remote/model/MapUiState.kt
+++ b/app/src/main/java/com/treasurehunt/data/remote/model/MapUiState.kt
@@ -7,5 +7,6 @@ data class MapUiState(
     val isSignedInAsMember: Boolean = false,
     val places: List<PlaceEntity> = listOf(),
     val plans: List<PlaceEntity> = listOf(),
-    val markers: List<Marker> = listOf()
+    val markers: List<Marker> = listOf(),
+    val isOnline: Boolean = false
 )

--- a/app/src/main/java/com/treasurehunt/data/remote/model/PlaceDTO.kt
+++ b/app/src/main/java/com/treasurehunt/data/remote/model/PlaceDTO.kt
@@ -9,12 +9,12 @@ data class PlaceDTO(
     val lng: Double,
     val plan: Boolean,
     val caption: String,
-    val remoteId: String? = null,
     val log: String? = null,
+    val remoteId: String? = null,
     val id: Long = 0
 )
 
 fun PlaceDTO.toPlaceEntity(): PlaceEntity {
-    val (lat, lng, plan, caption, remoteId, log, id) = this
-    return PlaceEntity(lat, lng, plan, caption, remoteId, log, id)
+    val (lat, lng, plan, caption, log, remoteId, id) = this
+    return PlaceEntity(lat, lng, plan, caption, log, remoteId, id)
 }

--- a/app/src/main/java/com/treasurehunt/data/remote/model/PlaceRemoteDataSource.kt
+++ b/app/src/main/java/com/treasurehunt/data/remote/model/PlaceRemoteDataSource.kt
@@ -4,5 +4,7 @@ import com.treasurehunt.data.remote.PlaceService
 
 class PlaceRemoteDataSource(private val placeService: PlaceService) {
 
+    suspend fun insert(placeDTO: PlaceDTO) = placeService.insert(placeDTO).name
+
     suspend fun getPlace(id: String) = placeService.getPlace(id)
 }

--- a/app/src/main/java/com/treasurehunt/data/remote/model/PlaceRemoteDataSource.kt
+++ b/app/src/main/java/com/treasurehunt/data/remote/model/PlaceRemoteDataSource.kt
@@ -7,4 +7,8 @@ class PlaceRemoteDataSource(private val placeService: PlaceService) {
     suspend fun insert(placeDTO: PlaceDTO) = placeService.insert(placeDTO).name
 
     suspend fun getPlace(id: String) = placeService.getPlace(id)
+
+    suspend fun update(id: String, placeDTO: PlaceDTO) {
+        placeService.update(id, placeDTO)
+    }
 }

--- a/app/src/main/java/com/treasurehunt/data/remote/model/RemoteIdWrapper.kt
+++ b/app/src/main/java/com/treasurehunt/data/remote/model/RemoteIdWrapper.kt
@@ -1,0 +1,6 @@
+package com.treasurehunt.data.remote.model
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class RemoteIdWrapper(val name: String)

--- a/app/src/main/java/com/treasurehunt/data/remote/model/UserDTO.kt
+++ b/app/src/main/java/com/treasurehunt/data/remote/model/UserDTO.kt
@@ -8,8 +8,15 @@ data class UserDTO(
     val nickname: String? = null,
     val profileImage: String? = null,
     val public: Boolean = false,
+<<<<<<< HEAD
     val friends: Map<String, Boolean> = emptyMap(),
     val logs: Map<String, Boolean> = emptyMap(),
     val places: Map<String, Boolean> = emptyMap(),
     val plans: Map<String, Boolean> = emptyMap(),
+=======
+    val friends: List<String> = emptyList(),
+    val logs: Map<String, Boolean> = emptyMap(),
+    val places: Map<String, Boolean> = emptyMap(),
+    val plans: Map<String, Boolean> = emptyMap()
+>>>>>>> 1af2985 (fix: UserDTO에 대해 logs, places, plans 프로퍼티를 리스트 -> 맵 타입으로 수정)
 )

--- a/app/src/main/java/com/treasurehunt/data/remote/model/UserDTO.kt
+++ b/app/src/main/java/com/treasurehunt/data/remote/model/UserDTO.kt
@@ -8,15 +8,8 @@ data class UserDTO(
     val nickname: String? = null,
     val profileImage: String? = null,
     val public: Boolean = false,
-<<<<<<< HEAD
     val friends: Map<String, Boolean> = emptyMap(),
     val logs: Map<String, Boolean> = emptyMap(),
     val places: Map<String, Boolean> = emptyMap(),
     val plans: Map<String, Boolean> = emptyMap(),
-=======
-    val friends: List<String> = emptyList(),
-    val logs: Map<String, Boolean> = emptyMap(),
-    val places: Map<String, Boolean> = emptyMap(),
-    val plans: Map<String, Boolean> = emptyMap()
->>>>>>> 1af2985 (fix: UserDTO에 대해 logs, places, plans 프로퍼티를 리스트 -> 맵 타입으로 수정)
 )

--- a/app/src/main/java/com/treasurehunt/data/remote/model/UserRemoteDataSource.kt
+++ b/app/src/main/java/com/treasurehunt/data/remote/model/UserRemoteDataSource.kt
@@ -13,5 +13,4 @@ class UserRemoteDataSource(private val userService: UserService) {
     }
 
     suspend fun getUserData(id: String) = userService.getUser(id)
-
 }

--- a/app/src/main/java/com/treasurehunt/ui/detail/DetailFragment.kt
+++ b/app/src/main/java/com/treasurehunt/ui/detail/DetailFragment.kt
@@ -98,7 +98,7 @@ class DetailFragment : BottomSheetDialogFragment() {
 
     private fun setEditButton() {
         binding.btnEdit.setOnClickListener {
-            findNavController().navigate(R.id.action_detailFragment_to_saveLogFragment)
+            findNavController().navigate(R.id.action_homeFragment_to_saveLogFragment)
         }
     }
 

--- a/app/src/main/java/com/treasurehunt/ui/detail/DetailFragment.kt
+++ b/app/src/main/java/com/treasurehunt/ui/detail/DetailFragment.kt
@@ -98,7 +98,7 @@ class DetailFragment : BottomSheetDialogFragment() {
 
     private fun setEditButton() {
         binding.btnEdit.setOnClickListener {
-            findNavController().navigate(R.id.action_homeFragment_to_saveLogFragment)
+            findNavController().navigate(R.id.action_detailFragment_to_saveLogFragment)
         }
     }
 
@@ -111,15 +111,5 @@ class DetailFragment : BottomSheetDialogFragment() {
     override fun onDestroyView() {
         super.onDestroyView()
         _binding = null
-    }
-
-    companion object {
-        fun newInstance(contentId: String): DetailFragment {
-            return DetailFragment().apply {
-                arguments = Bundle().apply {
-                    putString("content_id", contentId)
-                }
-            }
-        }
     }
 }

--- a/app/src/main/java/com/treasurehunt/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/treasurehunt/ui/home/HomeFragment.kt
@@ -4,6 +4,7 @@ import android.Manifest
 import android.content.pm.PackageManager
 import android.graphics.PointF
 import android.os.Bundle
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -19,6 +20,7 @@ import com.naver.maps.map.LocationTrackingMode
 import com.naver.maps.map.MapFragment
 import com.naver.maps.map.NaverMap
 import com.naver.maps.map.OnMapReadyCallback
+import com.naver.maps.map.overlay.Marker
 import com.naver.maps.map.overlay.OverlayImage
 import com.naver.maps.map.util.FusedLocationSource
 import com.treasurehunt.R
@@ -86,9 +88,13 @@ class HomeFragment : Fragment(), OnMapReadyCallback {
 
         showMarkers()
 
-        naverMap.setOnMapClickListener { coord, point ->
-            findNavController().navigate(R.id.action_homeFragment_to_detailFragment)
-        }
+        setPlaceClick()
+
+        //TODO
+//        naverMap.setOnMapClickListener { coord, point ->
+//            val bottomSheetFragment = BottomSheetFragment()
+//            bottomSheetFragment.show(childFragmentManager, bottomSheetFragment.tag)
+//        }
     }
 
     private fun initMap(naverMap: NaverMap) {
@@ -122,15 +128,44 @@ class HomeFragment : Fragment(), OnMapReadyCallback {
         locationOverlay.anchor = PointF(0.5f, 1f)
     }
 
+    private fun setPlaceClick() {
+        map.setOnSymbolClickListener { symbol ->
+            val mapSymbol = MapSymbol(
+                symbol.position.latitude,
+                symbol.position.longitude,
+                symbol.caption
+            )
+            val action = HomeFragmentDirections.actionHomeFragmentToMapDialogFragment(mapSymbol)
+            findNavController().navigate(action)
+            true
+        }
+    }
+
     private fun showMarkers() {
         viewLifecycleOwner.lifecycleScope.launch {
             repeatOnLifecycle(Lifecycle.State.STARTED) {
                 viewModel.uiState.collect { uiState ->
                     uiState.markers.forEach { marker ->
                         marker.map = map
+                        marker.setClick()
                     }
                 }
             }
+        }
+    }
+
+    private fun Marker.setClick() {
+        setOnClickListener {
+            if (tag == "place") {
+                Log.d("test$", captionText)
+                // open specific detail
+                val bottomSheetFragment = BottomSheetFragment()
+                bottomSheetFragment.show(childFragmentManager, bottomSheetFragment.tag)
+            } else {
+                Log.d("test$", captionText)
+                // navigate to save log
+            }
+            true
         }
     }
 

--- a/app/src/main/java/com/treasurehunt/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/treasurehunt/ui/home/HomeFragment.kt
@@ -26,7 +26,6 @@ import com.treasurehunt.R
 import com.treasurehunt.databinding.FragmentHomeBinding
 import kotlinx.coroutines.launch
 import com.treasurehunt.ui.detail.DetailFragment
-import com.treasurehunt.ui.home.HomeFragmentDirections.Companion.actionHomeFragmentToSaveLogFragment
 
 class HomeFragment : Fragment(), OnMapReadyCallback {
 
@@ -166,7 +165,7 @@ class HomeFragment : Fragment(), OnMapReadyCallback {
     private fun Marker.setPlanClick(contentId: String) {
         setOnClickListener {
             viewLifecycleOwner.lifecycleScope.launch {
-                val plan = viewModel.getPlanById(contentId)
+                val plan = viewModel.getRemotePlaceById(contentId)
                 val mapSymbol = MapSymbol(
                     plan.lat,
                     plan.lng,

--- a/app/src/main/java/com/treasurehunt/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/treasurehunt/ui/home/HomeFragment.kt
@@ -167,7 +167,8 @@ class HomeFragment : Fragment(), OnMapReadyCallback {
         val remotePlaceId = tag.toString()
 
         setOnClickListener {
-            showLogDetailBottomSheet(remotePlaceId)
+            val action = HomeFragmentDirections.actionHomeFragmentToDetailFragment(remotePlaceId)
+            findNavController().navigate(action)
             true
         }
     }
@@ -197,11 +198,6 @@ class HomeFragment : Fragment(), OnMapReadyCallback {
 
             true
         }
-    }
-
-    private fun showLogDetailBottomSheet(placeId: String) {
-        val detailFragment = DetailFragment.newInstance(placeId)
-        detailFragment.show(childFragmentManager, detailFragment.tag)
     }
 
     companion object {

--- a/app/src/main/java/com/treasurehunt/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/treasurehunt/ui/home/HomeFragment.kt
@@ -15,7 +15,6 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import androidx.navigation.fragment.findNavController
-import androidx.navigation.fragment.navArgs
 import com.naver.maps.map.LocationTrackingMode
 import com.naver.maps.map.MapFragment
 import com.naver.maps.map.NaverMap
@@ -26,7 +25,6 @@ import com.naver.maps.map.util.FusedLocationSource
 import com.treasurehunt.R
 import com.treasurehunt.databinding.FragmentHomeBinding
 import com.treasurehunt.ui.detail.DetailFragment
-import kotlinx.coroutines.async
 import kotlinx.coroutines.launch
 
 class HomeFragment : Fragment(), OnMapReadyCallback {
@@ -41,7 +39,6 @@ class HomeFragment : Fragment(), OnMapReadyCallback {
         registerForActivityResult(RequestPermission()) { isGranted ->
             setLocationTrackingMode(isGranted)
         }
-    private val args: HomeFragmentArgs by navArgs()
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?
@@ -179,7 +176,7 @@ class HomeFragment : Fragment(), OnMapReadyCallback {
         setOnClickListener {
             val uid = viewModel.uiState.value.uid ?: return@setOnClickListener false
 
-            viewLifecycleOwner.lifecycleScope.async {
+            viewLifecycleOwner.lifecycleScope.launch {
                 val plan = viewModel.getRemotePlaceById(remotePlaceId)
                 val mapSymbol = MapSymbol(
                     plan.lat,

--- a/app/src/main/java/com/treasurehunt/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/treasurehunt/ui/home/HomeFragment.kt
@@ -25,6 +25,7 @@ import com.naver.maps.map.util.FusedLocationSource
 import com.treasurehunt.R
 import com.treasurehunt.databinding.FragmentHomeBinding
 import com.treasurehunt.ui.detail.DetailFragment
+import com.treasurehunt.ui.model.MapSymbol
 import kotlinx.coroutines.launch
 
 class HomeFragment : Fragment(), OnMapReadyCallback {

--- a/app/src/main/java/com/treasurehunt/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/treasurehunt/ui/home/HomeFragment.kt
@@ -4,6 +4,7 @@ import android.Manifest
 import android.content.pm.PackageManager
 import android.graphics.PointF
 import android.os.Bundle
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -118,9 +119,10 @@ class HomeFragment : Fragment(), OnMapReadyCallback {
 
     private fun setSymbolClick() {
         map.setOnSymbolClickListener { symbol ->
-            if (!viewModel.uiState.value.isOnline) return@setOnSymbolClickListener false
+            if (!viewModel.uiState.value.isOnline || viewModel.uiState.value.uid.isNullOrEmpty()) {
+                return@setOnSymbolClickListener false
+            }
 
-            val uid = viewModel.uiState.value.uid ?: return@setOnSymbolClickListener false
             val mapSymbol = MapSymbol(
                 symbol.position.latitude,
                 symbol.position.longitude,
@@ -128,7 +130,6 @@ class HomeFragment : Fragment(), OnMapReadyCallback {
             )
             val action =
                 HomeFragmentDirections.actionHomeFragmentToMapDialogFragment(
-                    uid,
                     mapSymbol
                 )
 
@@ -141,7 +142,9 @@ class HomeFragment : Fragment(), OnMapReadyCallback {
     private fun showMarkers() {
         viewLifecycleOwner.lifecycleScope.launch {
             repeatOnLifecycle(Lifecycle.State.STARTED) {
+                Log.d("fm test$", "before collecting")
                 viewModel.uiState.collect { uiState ->
+                    Log.d("fm test$", uiState.uid.toString())
                     if (uiState.uid == null) return@collect
 
                     uiState.visitMarkers.forEach { marker ->
@@ -187,7 +190,6 @@ class HomeFragment : Fragment(), OnMapReadyCallback {
                     remotePlaceId
                 )
                 val action = HomeFragmentDirections.actionHomeFragmentToSaveLogFragment(
-                    uid,
                     mapSymbol
                 )
                 findNavController().navigate(action)

--- a/app/src/main/java/com/treasurehunt/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/treasurehunt/ui/home/HomeFragment.kt
@@ -142,9 +142,7 @@ class HomeFragment : Fragment(), OnMapReadyCallback {
     private fun showMarkers() {
         viewLifecycleOwner.lifecycleScope.launch {
             repeatOnLifecycle(Lifecycle.State.STARTED) {
-                Log.d("fm test$", "before collecting")
                 viewModel.uiState.collect { uiState ->
-                    Log.d("fm test$", uiState.uid.toString())
                     if (uiState.uid == null) return@collect
 
                     uiState.visitMarkers.forEach { marker ->
@@ -178,7 +176,9 @@ class HomeFragment : Fragment(), OnMapReadyCallback {
         val remotePlaceId = tag.toString()
 
         setOnClickListener {
-            val uid = viewModel.uiState.value.uid ?: return@setOnClickListener false
+            if (!viewModel.uiState.value.isOnline || viewModel.uiState.value.uid.isNullOrEmpty()) {
+                return@setOnClickListener false
+            }
 
             viewLifecycleOwner.lifecycleScope.launch {
                 val plan = viewModel.getRemotePlaceById(remotePlaceId)

--- a/app/src/main/java/com/treasurehunt/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/treasurehunt/ui/home/HomeFragment.kt
@@ -149,20 +149,20 @@ class HomeFragment : Fragment(), OnMapReadyCallback {
                 viewModel.uiState.collect { uiState ->
                     uiState.markers.forEach { marker ->
                         marker.map = map
-                        marker.setClick()
+                        val placeId = ""
+                        marker.setClick(placeId)
                     }
                 }
             }
         }
     }
 
-    private fun Marker.setClick() {
+    private fun Marker.setClick(contentId: String) {
         setOnClickListener {
             if (tag == "place") {
                 Log.d("test$", captionText)
                 // open specific detail
-                val bottomSheetFragment = BottomSheetFragment()
-                bottomSheetFragment.show(childFragmentManager, bottomSheetFragment.tag)
+                showMarkerBottomSheet(contentId)
             } else {
                 Log.d("test$", captionText)
                 // navigate to save log

--- a/app/src/main/java/com/treasurehunt/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/treasurehunt/ui/home/HomeFragment.kt
@@ -88,7 +88,7 @@ class HomeFragment : Fragment(), OnMapReadyCallback {
 
         showMarkers()
 
-        setPlaceClick()
+        setSymbolClick()
 
         //TODO
 //        naverMap.setOnMapClickListener { coord, point ->
@@ -128,8 +128,10 @@ class HomeFragment : Fragment(), OnMapReadyCallback {
         locationOverlay.anchor = PointF(0.5f, 1f)
     }
 
-    private fun setPlaceClick() {
+    private fun setSymbolClick() {
         map.setOnSymbolClickListener { symbol ->
+            if (!viewModel.uiState.value.isOnline) return@setOnSymbolClickListener false
+
             val mapSymbol = MapSymbol(
                 symbol.position.latitude,
                 symbol.position.longitude,

--- a/app/src/main/java/com/treasurehunt/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/treasurehunt/ui/home/HomeFragment.kt
@@ -4,7 +4,6 @@ import android.Manifest
 import android.content.pm.PackageManager
 import android.graphics.PointF
 import android.os.Bundle
-import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -25,7 +24,6 @@ import com.naver.maps.map.overlay.OverlayImage
 import com.naver.maps.map.util.FusedLocationSource
 import com.treasurehunt.R
 import com.treasurehunt.databinding.FragmentHomeBinding
-import com.treasurehunt.ui.detail.DetailFragment
 import com.treasurehunt.ui.model.MapSymbol
 import kotlinx.coroutines.launch
 

--- a/app/src/main/java/com/treasurehunt/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/treasurehunt/ui/home/HomeViewModel.kt
@@ -1,11 +1,8 @@
 package com.treasurehunt.ui.home
 
-import android.util.Log
-import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.ViewModelProvider.AndroidViewModelFactory.Companion.APPLICATION_KEY
-import androidx.lifecycle.createSavedStateHandle
 import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.CreationExtras
 import com.google.firebase.auth.ktx.auth
@@ -21,9 +18,9 @@ import com.treasurehunt.data.LogRepository
 import com.treasurehunt.data.PlaceRepository
 import com.treasurehunt.data.UserRepository
 import com.treasurehunt.data.local.model.PlaceEntity
-import com.treasurehunt.ui.model.MapUiState
 import com.treasurehunt.data.remote.model.PlaceDTO
 import com.treasurehunt.data.remote.model.UserDTO
+import com.treasurehunt.ui.model.MapUiState
 import com.treasurehunt.util.ConnectivityRepository
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
@@ -62,7 +59,6 @@ class HomeViewModel(
 
         viewModelScope.launch {
             _uiState.update {
-                Log.d("vm test$", uid.toString())
                 it.copy(uid = uid)
             }
         }

--- a/app/src/main/java/com/treasurehunt/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/treasurehunt/ui/home/HomeViewModel.kt
@@ -26,7 +26,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.merge
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import java.io.IOException
@@ -106,7 +106,11 @@ class HomeViewModel(
 
         fetchJob = viewModelScope.launch {
             try {
-                merge(placeRepo.getAllVisits(), placeRepo.getAllPlans()).collect { visitsAndPlans ->
+                placeRepo.getAllVisits().combine(placeRepo.getAllPlans()) { visits, plans ->
+                    visits + plans
+                }
+//                merge(placeRepo.getAllPlaces(), placeRepo.getAllPlans())
+                    .collect { visitsAndPlans ->
                     _uiState.update { uiState ->
                         val (places, plans) = visitsAndPlans.partition { !it.plan }
                         uiState.copy(

--- a/app/src/main/java/com/treasurehunt/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/treasurehunt/ui/home/HomeViewModel.kt
@@ -1,5 +1,6 @@
 package com.treasurehunt.ui.home
 
+import android.util.Log
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
@@ -7,6 +8,8 @@ import androidx.lifecycle.ViewModelProvider.AndroidViewModelFactory.Companion.AP
 import androidx.lifecycle.createSavedStateHandle
 import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.CreationExtras
+import com.google.firebase.auth.ktx.auth
+import com.google.firebase.ktx.Firebase
 import com.naver.maps.geometry.LatLng
 import com.naver.maps.map.overlay.Marker
 import com.naver.maps.map.overlay.OverlayImage
@@ -35,8 +38,7 @@ class HomeViewModel(
     private val logRepo: LogRepository,
     private val placeRepo: PlaceRepository,
     private val userRepo: UserRepository,
-    private val connectivityRepo: ConnectivityRepository,
-    private val savedStateHandle: SavedStateHandle
+    private val connectivityRepo: ConnectivityRepository
 ) :
     ViewModel() {
 
@@ -56,10 +58,11 @@ class HomeViewModel(
     }
 
     private fun initUser() {
-        val uid = HomeFragmentArgs.fromSavedStateHandle(savedStateHandle).uid
+        val uid = Firebase.auth.currentUser?.uid
 
         viewModelScope.launch {
             _uiState.update {
+                Log.d("vm test$", uid.toString())
                 it.copy(uid = uid)
             }
         }
@@ -167,8 +170,7 @@ class HomeViewModel(
                     logRepo,
                     placeRepo,
                     userRepo,
-                    ConnectivityRepository(application.applicationContext),
-                    extras.createSavedStateHandle()
+                    ConnectivityRepository(application.applicationContext)
                 ) as T
             }
         }

--- a/app/src/main/java/com/treasurehunt/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/treasurehunt/ui/home/HomeViewModel.kt
@@ -108,8 +108,8 @@ class HomeViewModel(
 
         fetchJob = viewModelScope.launch {
             try {
-                placeRepo.getAllVisits().combine(placeRepo.getAllPlans()) { visits, plans ->
-                    visits + plans
+                combine(placeRepo.getAllVisits(), placeRepo.getAllPlans()) { places, plans ->
+                    places + plans
                 }
                     .stateIn(viewModelScope, SharingStarted.WhileSubscribed(), emptyList())
                     .collect { visitsAndPlans ->

--- a/app/src/main/java/com/treasurehunt/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/treasurehunt/ui/home/HomeViewModel.kt
@@ -18,7 +18,7 @@ import com.treasurehunt.data.LogRepository
 import com.treasurehunt.data.PlaceRepository
 import com.treasurehunt.data.UserRepository
 import com.treasurehunt.data.local.model.PlaceEntity
-import com.treasurehunt.data.remote.model.MapUiState
+import com.treasurehunt.ui.model.MapUiState
 import com.treasurehunt.data.remote.model.PlaceDTO
 import com.treasurehunt.data.remote.model.UserDTO
 import com.treasurehunt.util.ConnectivityRepository

--- a/app/src/main/java/com/treasurehunt/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/treasurehunt/ui/home/HomeViewModel.kt
@@ -25,8 +25,10 @@ import com.treasurehunt.util.ConnectivityRepository
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import java.io.IOException
@@ -109,16 +111,16 @@ class HomeViewModel(
                 placeRepo.getAllVisits().combine(placeRepo.getAllPlans()) { visits, plans ->
                     visits + plans
                 }
-//                merge(placeRepo.getAllPlaces(), placeRepo.getAllPlans())
+                    .stateIn(viewModelScope, SharingStarted.WhileSubscribed(), emptyList())
                     .collect { visitsAndPlans ->
-                    _uiState.update { uiState ->
-                        val (places, plans) = visitsAndPlans.partition { !it.plan }
-                        uiState.copy(
-                            visitMarkers = places.mapToMarkers(),
-                            planMarkers = plans.mapToMarkers()
-                        )
+                        _uiState.update { uiState ->
+                            val (places, plans) = visitsAndPlans.partition { !it.plan }
+                            uiState.copy(
+                                visitMarkers = places.mapToMarkers(),
+                                planMarkers = plans.mapToMarkers()
+                            )
+                        }
                     }
-                }
             } catch (e: IOException) {
             }
         }

--- a/app/src/main/java/com/treasurehunt/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/treasurehunt/ui/home/HomeViewModel.kt
@@ -31,8 +31,13 @@ class HomeViewModel(private val logRepo: LogRepository, private val placeRepo: P
     private var fetchJob: Job? = null
 
     init {
-        storeSampleData()
         getAllMarkers()
+    }
+
+    fun addPlan(plan: PlaceEntity) {
+        viewModelScope.launch {
+            placeRepo.insert(plan)
+        }
     }
 
     private fun getAllMarkers() {
@@ -57,6 +62,7 @@ class HomeViewModel(private val logRepo: LogRepository, private val placeRepo: P
     private fun Marker.from(place: PlaceEntity): Marker {
         return if (!place.plan) {
             apply {
+                tag = "place"
                 captionText = place.caption
                 icon = OverlayImage.fromResource(R.drawable.ic_chest_open)
                 width = 116
@@ -64,6 +70,7 @@ class HomeViewModel(private val logRepo: LogRepository, private val placeRepo: P
             }
         } else {
             apply {
+                tag = "plan"
                 captionText = place.caption
                 icon = OverlayImage.fromResource(R.drawable.ic_chest_closed)
                 width = 96

--- a/app/src/main/java/com/treasurehunt/ui/home/MapDialogFragment.kt
+++ b/app/src/main/java/com/treasurehunt/ui/home/MapDialogFragment.kt
@@ -1,0 +1,59 @@
+package com.treasurehunt.ui.home
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.view.ViewGroup.LayoutParams.MATCH_PARENT
+import androidx.fragment.app.DialogFragment
+import androidx.fragment.app.viewModels
+import androidx.navigation.fragment.findNavController
+import androidx.navigation.fragment.navArgs
+import com.treasurehunt.data.model.PlaceEntity
+import com.treasurehunt.databinding.FragmentMapDialogBinding
+
+class MapDialogFragment : DialogFragment() {
+
+    private var _binding: FragmentMapDialogBinding? = null
+    private val binding get() = _binding!!
+    private val viewModel: HomeViewModel by viewModels { HomeViewModel.Factory } // share?
+    private val args: MapDialogFragmentArgs by navArgs()
+
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        _binding = FragmentMapDialogBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        dialog?.window?.setLayout(400, MATCH_PARENT)
+
+        binding.btnPlace.setOnClickListener {
+            // findNavController() -> save log fragment
+        }
+
+        binding.btnPlan.setOnClickListener {
+            val (lat, lng, caption) = args.MapSymbol
+            val plan = PlaceEntity(
+                lat,
+                lng,
+                true,
+                caption
+            )
+            viewModel.addPlan(plan)
+            findNavController().navigateUp()
+        }
+
+        binding.btnCancel.setOnClickListener {
+            findNavController().navigateUp()
+        }
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        _binding = null
+    }
+}

--- a/app/src/main/java/com/treasurehunt/ui/home/MapDialogFragment.kt
+++ b/app/src/main/java/com/treasurehunt/ui/home/MapDialogFragment.kt
@@ -5,9 +5,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.viewModels
-import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
-import androidx.lifecycle.repeatOnLifecycle
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
@@ -72,6 +70,7 @@ class MapDialogFragment : BottomSheetDialogFragment() {
                 true,
                 caption
             )
+
             viewLifecycleOwner.lifecycleScope.launch {
                 val user = viewModel.getRemoteUser(uid)
                 val localPlanId = viewModel.addPlace(planEntity)

--- a/app/src/main/java/com/treasurehunt/ui/home/MapDialogFragment.kt
+++ b/app/src/main/java/com/treasurehunt/ui/home/MapDialogFragment.kt
@@ -4,11 +4,11 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.view.ViewGroup.LayoutParams.MATCH_PARENT
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
+import com.treasurehunt.R
 import com.treasurehunt.data.local.model.PlaceEntity
 import com.treasurehunt.databinding.FragmentMapDialogBinding
 
@@ -29,12 +29,25 @@ class MapDialogFragment : BottomSheetDialogFragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        setPrompt()
+        setBtnPlace()
+        setBtnPlan()
+        setBtnCancel()
+    }
 
+    private fun setPrompt() {
+        binding.tvTitle.text = getString(R.string.map_prompt, args.MapSymbol.caption)
+    }
+
+    private fun setBtnPlace() {
         binding.btnPlace.setOnClickListener {
-            val action = MapDialogFragmentDirections.actionMapDialogFragmentToSaveLogFragment(args.MapSymbol)
+            val action =
+                MapDialogFragmentDirections.actionMapDialogFragmentToSaveLogFragment(args.MapSymbol)
             findNavController().navigate(action)
         }
+    }
 
+    private fun setBtnPlan() {
         binding.btnPlan.setOnClickListener {
             val (lat, lng, caption) = args.MapSymbol
             val plan = PlaceEntity(
@@ -46,7 +59,9 @@ class MapDialogFragment : BottomSheetDialogFragment() {
             viewModel.addPlan(plan)
             findNavController().navigateUp()
         }
+    }
 
+    private fun setBtnCancel() {
         binding.btnCancel.setOnClickListener {
             findNavController().navigateUp()
         }

--- a/app/src/main/java/com/treasurehunt/ui/home/MapDialogFragment.kt
+++ b/app/src/main/java/com/treasurehunt/ui/home/MapDialogFragment.kt
@@ -5,12 +5,17 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.viewModels
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import com.treasurehunt.R
 import com.treasurehunt.data.local.model.PlaceEntity
+import com.treasurehunt.data.remote.model.PlaceDTO
 import com.treasurehunt.databinding.FragmentMapDialogBinding
+import kotlinx.coroutines.launch
 
 class MapDialogFragment : BottomSheetDialogFragment() {
 
@@ -36,28 +41,50 @@ class MapDialogFragment : BottomSheetDialogFragment() {
     }
 
     private fun setPrompt() {
-        binding.tvTitle.text = getString(R.string.map_prompt, args.MapSymbol.caption)
+        binding.tvTitle.text = getString(R.string.map_prompt, args.mapSymbol.caption)
     }
 
     private fun setBtnPlace() {
         binding.btnPlace.setOnClickListener {
+            val uid = viewModel.uiState.value.uid ?: return@setOnClickListener
             val action =
-                MapDialogFragmentDirections.actionMapDialogFragmentToSaveLogFragment(args.MapSymbol)
+                MapDialogFragmentDirections.actionMapDialogFragmentToSaveLogFragment(
+                    uid,
+                    args.mapSymbol
+                )
             findNavController().navigate(action)
         }
     }
 
     private fun setBtnPlan() {
         binding.btnPlan.setOnClickListener {
-            val (lat, lng, caption) = args.MapSymbol
-            val plan = PlaceEntity(
+            val uid = viewModel.uiState.value.uid ?: return@setOnClickListener
+            val (lat, lng, caption) = args.mapSymbol
+            val planEntity = PlaceEntity(
                 lat,
                 lng,
                 true,
                 caption
             )
-            viewModel.addPlace(plan)
-            findNavController().navigateUp()
+            val planDTO = PlaceDTO(
+                lat,
+                lng,
+                true,
+                caption
+            )
+            viewLifecycleOwner.lifecycleScope.launch {
+                val user = viewModel.getRemoteUser(uid)
+                val localPlanId = viewModel.addPlace(planEntity)
+                val remotePlanId = viewModel.addPlace(planDTO.copy(id = localPlanId))
+                viewModel.updatePlace(planEntity.copy(id = localPlanId, remoteId = remotePlanId))
+                viewModel.updatePlace(
+                    remotePlanId,
+                    planDTO.copy(id = localPlanId, remoteId = remotePlanId)
+                )
+                viewModel.updateUser(uid, user.copy(plans = user.plans + remotePlanId))
+
+                findNavController().navigateUp()
+            }
         }
     }
 

--- a/app/src/main/java/com/treasurehunt/ui/home/MapDialogFragment.kt
+++ b/app/src/main/java/com/treasurehunt/ui/home/MapDialogFragment.kt
@@ -56,7 +56,7 @@ class MapDialogFragment : BottomSheetDialogFragment() {
                 true,
                 caption
             )
-            viewModel.addPlan(plan)
+            viewModel.addPlace(plan)
             findNavController().navigateUp()
         }
     }

--- a/app/src/main/java/com/treasurehunt/ui/home/MapDialogFragment.kt
+++ b/app/src/main/java/com/treasurehunt/ui/home/MapDialogFragment.kt
@@ -44,10 +44,12 @@ class MapDialogFragment : BottomSheetDialogFragment() {
 
     private fun setBtnPlace() {
         binding.btnPlace.setOnClickListener {
-            val uid = viewModel.uiState.value.uid ?: return@setOnClickListener
+            if (viewModel.uiState.value.uid.isNullOrEmpty()) {
+                findNavController().navigateUp()
+            }
+
             val action =
                 MapDialogFragmentDirections.actionMapDialogFragmentToSaveLogFragment(
-                    uid,
                     args.mapSymbol
                 )
             findNavController().navigate(action)
@@ -56,6 +58,10 @@ class MapDialogFragment : BottomSheetDialogFragment() {
 
     private fun setBtnPlan() {
         binding.btnPlan.setOnClickListener {
+            if (viewModel.uiState.value.uid.isNullOrEmpty()) {
+                findNavController().navigateUp()
+            }
+
             val uid = viewModel.uiState.value.uid ?: return@setOnClickListener
             val (lat, lng, caption) = args.mapSymbol
             val planEntity = PlaceEntity(

--- a/app/src/main/java/com/treasurehunt/ui/home/MapDialogFragment.kt
+++ b/app/src/main/java/com/treasurehunt/ui/home/MapDialogFragment.kt
@@ -5,14 +5,14 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.view.ViewGroup.LayoutParams.MATCH_PARENT
-import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
-import com.treasurehunt.data.model.PlaceEntity
+import com.google.android.material.bottomsheet.BottomSheetDialogFragment
+import com.treasurehunt.data.local.model.PlaceEntity
 import com.treasurehunt.databinding.FragmentMapDialogBinding
 
-class MapDialogFragment : DialogFragment() {
+class MapDialogFragment : BottomSheetDialogFragment() {
 
     private var _binding: FragmentMapDialogBinding? = null
     private val binding get() = _binding!!
@@ -22,17 +22,17 @@ class MapDialogFragment : DialogFragment() {
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
-    ): View? {
+    ): View {
         _binding = FragmentMapDialogBinding.inflate(inflater, container, false)
         return binding.root
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        dialog?.window?.setLayout(400, MATCH_PARENT)
 
         binding.btnPlace.setOnClickListener {
-            // findNavController() -> save log fragment
+            val action = MapDialogFragmentDirections.actionMapDialogFragmentToSaveLogFragment(args.MapSymbol)
+            findNavController().navigate(action)
         }
 
         binding.btnPlan.setOnClickListener {

--- a/app/src/main/java/com/treasurehunt/ui/home/MapDialogFragment.kt
+++ b/app/src/main/java/com/treasurehunt/ui/home/MapDialogFragment.kt
@@ -80,7 +80,7 @@ class MapDialogFragment : BottomSheetDialogFragment() {
                     remotePlanId,
                     planDTO.copy(id = localPlanId, remoteId = remotePlanId)
                 )
-                viewModel.updateUser(uid, user.copy(plans = user.plans + remotePlanId))
+                viewModel.updateUser(uid, user.copy(plans = user.plans + (remotePlanId to true)))
 
                 findNavController().navigateUp()
             }

--- a/app/src/main/java/com/treasurehunt/ui/home/MapSymbol.kt
+++ b/app/src/main/java/com/treasurehunt/ui/home/MapSymbol.kt
@@ -7,6 +7,8 @@ import android.os.Parcelable
 data class MapSymbol(
     val lat: Double,
     val lng: Double,
-    val caption: String
+    val caption: String,
+    val isPlan: Boolean = false,
+    val remoteId: String? = null
 ) : Parcelable
 

--- a/app/src/main/java/com/treasurehunt/ui/home/MapSymbol.kt
+++ b/app/src/main/java/com/treasurehunt/ui/home/MapSymbol.kt
@@ -1,0 +1,12 @@
+package com.treasurehunt.ui.home
+
+import kotlinx.parcelize.Parcelize
+import android.os.Parcelable
+
+@Parcelize
+data class MapSymbol(
+    val lat: Double,
+    val lng: Double,
+    val caption: String
+) : Parcelable
+

--- a/app/src/main/java/com/treasurehunt/ui/login/LogInFragment.kt
+++ b/app/src/main/java/com/treasurehunt/ui/login/LogInFragment.kt
@@ -114,7 +114,9 @@ class LogInFragment : Fragment() {
                 if (task.isSuccessful) {
                     lifecycleScope.launch {
                         viewModel.initLocalData()
-                        findNavController().navigate(R.id.action_logInFragment_to_homeFragment)
+                        val action =
+                            LogInFragmentDirections.actionLogInFragmentToHomeFragment(user.id)
+                        findNavController().navigate(action)
                     }
                 } else {
                     createAccount(user)
@@ -129,7 +131,9 @@ class LogInFragment : Fragment() {
                 if (task.isSuccessful) {
                     lifecycleScope.launch {
                         viewModel.insertNaverUser(user)
-                        findNavController().navigate(R.id.action_logInFragment_to_homeFragment)
+                        val action =
+                            LogInFragmentDirections.actionLogInFragmentToHomeFragment(user.id)
+                        findNavController().navigate(action)
                     }
                 }
             }
@@ -142,7 +146,9 @@ class LogInFragment : Fragment() {
                     if (task.isSuccessful) {
                         lifecycleScope.launch {
                             viewModel.insertGuestUser()
-                            findNavController().navigate(R.id.action_logInFragment_to_homeFragment)
+                            val action =
+                                LogInFragmentDirections.actionLogInFragmentToHomeFragment(Firebase.auth.currentUser!!.uid)
+                            findNavController().navigate(action)
                         }
                     }
                 }

--- a/app/src/main/java/com/treasurehunt/ui/login/LogInFragment.kt
+++ b/app/src/main/java/com/treasurehunt/ui/login/LogInFragment.kt
@@ -114,9 +114,7 @@ class LogInFragment : Fragment() {
                 if (task.isSuccessful) {
                     lifecycleScope.launch {
                         viewModel.initLocalData()
-                        val action =
-                            LogInFragmentDirections.actionLogInFragmentToHomeFragment(user.id)
-                        findNavController().navigate(action)
+                        findNavController().navigate(R.id.action_logInFragment_to_homeFragment)
                     }
                 } else {
                     createAccount(user)
@@ -131,9 +129,7 @@ class LogInFragment : Fragment() {
                 if (task.isSuccessful) {
                     lifecycleScope.launch {
                         viewModel.insertNaverUser(user)
-                        val action =
-                            LogInFragmentDirections.actionLogInFragmentToHomeFragment(user.id)
-                        findNavController().navigate(action)
+                        findNavController().navigate(R.id.action_logInFragment_to_homeFragment)
                     }
                 }
             }
@@ -146,9 +142,7 @@ class LogInFragment : Fragment() {
                     if (task.isSuccessful) {
                         lifecycleScope.launch {
                             viewModel.insertGuestUser()
-                            val action =
-                                LogInFragmentDirections.actionLogInFragmentToHomeFragment(Firebase.auth.currentUser!!.uid)
-                            findNavController().navigate(action)
+                            findNavController().navigate(R.id.action_logInFragment_to_homeFragment)
                         }
                     }
                 }

--- a/app/src/main/java/com/treasurehunt/ui/login/LoginViewModel.kt
+++ b/app/src/main/java/com/treasurehunt/ui/login/LoginViewModel.kt
@@ -1,7 +1,6 @@
 package com.treasurehunt.ui.login
 
 import android.net.Uri
-import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewmodel.CreationExtras
@@ -41,8 +40,9 @@ class LoginViewModel(
 
     suspend fun insertGuestUser() {
         val currentUser = Firebase.auth.currentUser!!
-        // 테스트 샘플
-        val userDTO = UserDTO(email = "")
+        val userDTO = UserDTO(
+            email = currentUser.email ?: ""
+        )
         userRepository.insert(currentUser.uid, userDTO)
     }
 

--- a/app/src/main/java/com/treasurehunt/ui/login/SplashFragment.kt
+++ b/app/src/main/java/com/treasurehunt/ui/login/SplashFragment.kt
@@ -33,8 +33,8 @@ class SplashFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-
-        initSplashScreen()
+        findNavController().navigate(R.id.action_splashFragment_to_homeFragment)
+//        initSplashScreen()
     }
 
     override fun onDestroyView() {
@@ -56,5 +56,4 @@ class SplashFragment : Fragment() {
             }
         }
     }
-
 }

--- a/app/src/main/java/com/treasurehunt/ui/login/SplashFragment.kt
+++ b/app/src/main/java/com/treasurehunt/ui/login/SplashFragment.kt
@@ -51,8 +51,7 @@ class SplashFragment : Fragment() {
             else {
                 lifecycleScope.launch {
                     viewModel.initLocalData()
-                    val action = SplashFragmentDirections.actionSplashFragmentToHomeFragment(currentUser.uid)
-                    findNavController().navigate(action)
+                    findNavController().navigate(R.id.action_splashFragment_to_homeFragment)
                 }
             }
         }

--- a/app/src/main/java/com/treasurehunt/ui/login/SplashFragment.kt
+++ b/app/src/main/java/com/treasurehunt/ui/login/SplashFragment.kt
@@ -46,11 +46,13 @@ class SplashFragment : Fragment() {
         binding.animationView.playAnimation()
         lifecycleScope.launch {
             delay(2000)
-            if (Firebase.auth.currentUser == null) findNavController().navigate(R.id.action_splashFragment_to_logInFragment)
+            val currentUser = Firebase.auth.currentUser
+            if (currentUser == null) findNavController().navigate(R.id.action_splashFragment_to_logInFragment)
             else {
                 lifecycleScope.launch {
                     viewModel.initLocalData()
-                    findNavController().navigate(R.id.action_splashFragment_to_homeFragment)
+                    val action = SplashFragmentDirections.actionSplashFragmentToHomeFragment(currentUser.uid)
+                    findNavController().navigate(action)
                 }
             }
         }

--- a/app/src/main/java/com/treasurehunt/ui/login/SplashFragment.kt
+++ b/app/src/main/java/com/treasurehunt/ui/login/SplashFragment.kt
@@ -33,8 +33,7 @@ class SplashFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        findNavController().navigate(R.id.action_splashFragment_to_homeFragment)
-//        initSplashScreen()
+        initSplashScreen()
     }
 
     override fun onDestroyView() {

--- a/app/src/main/java/com/treasurehunt/ui/model/LogModel.kt
+++ b/app/src/main/java/com/treasurehunt/ui/model/LogModel.kt
@@ -1,0 +1,22 @@
+package com.treasurehunt.ui.model
+
+import com.treasurehunt.data.local.model.LogEntity
+import com.treasurehunt.data.remote.model.LogDTO
+
+data class LogModel(
+    val place: String,
+    val images: List<String>,
+    val text: String,
+    val theme: String,
+    val createdDate: Long
+)
+
+fun LogModel.asLogEntity(remoteId: String? = null, localId: Long = 0): LogEntity {
+    val (place, images, text, theme, createdDate) = this
+    return LogEntity(place, images, text, theme, createdDate)
+}
+
+fun LogModel.asLogDTO(remoteId: String? = null, localId: Long = 0): LogDTO {
+    val (place, images, text, theme, createdDate) = this
+    return LogDTO(place, images, text, theme, createdDate)
+}

--- a/app/src/main/java/com/treasurehunt/ui/model/LogModel.kt
+++ b/app/src/main/java/com/treasurehunt/ui/model/LogModel.kt
@@ -18,5 +18,5 @@ fun LogModel.asLogEntity(remoteId: String? = null, localId: Long = 0): LogEntity
 
 fun LogModel.asLogDTO(remoteId: String? = null, localId: Long = 0): LogDTO {
     val (place, images, text, theme, createdDate) = this
-    return LogDTO(place, images, text, theme, createdDate)
+    return LogDTO(place, images.associateWith { true }, text, theme, createdDate)
 }

--- a/app/src/main/java/com/treasurehunt/ui/model/MapSymbol.kt
+++ b/app/src/main/java/com/treasurehunt/ui/model/MapSymbol.kt
@@ -1,4 +1,4 @@
-package com.treasurehunt.ui.home
+package com.treasurehunt.ui.model
 
 import kotlinx.parcelize.Parcelize
 import android.os.Parcelable

--- a/app/src/main/java/com/treasurehunt/ui/model/MapSymbol.kt
+++ b/app/src/main/java/com/treasurehunt/ui/model/MapSymbol.kt
@@ -12,3 +12,12 @@ data class MapSymbol(
     val remoteId: String? = null
 ) : Parcelable
 
+fun MapSymbol.toPlace(): PlaceModel {
+    val (lat, lng, caption) = this
+    return PlaceModel(
+        lat,
+        lng,
+        false,
+        caption
+    )
+}

--- a/app/src/main/java/com/treasurehunt/ui/model/MapUiState.kt
+++ b/app/src/main/java/com/treasurehunt/ui/model/MapUiState.kt
@@ -1,4 +1,4 @@
-package com.treasurehunt.data.remote.model
+package com.treasurehunt.ui.model
 
 import com.naver.maps.map.overlay.Marker
 import com.treasurehunt.data.local.model.PlaceEntity

--- a/app/src/main/java/com/treasurehunt/ui/model/PlaceModel.kt
+++ b/app/src/main/java/com/treasurehunt/ui/model/PlaceModel.kt
@@ -1,0 +1,22 @@
+package com.treasurehunt.ui.model
+
+import com.treasurehunt.data.local.model.PlaceEntity
+import com.treasurehunt.data.remote.model.PlaceDTO
+
+data class PlaceModel(
+    val lat: Double,
+    val lng: Double,
+    val plan: Boolean,
+    val caption: String,
+    val log: String? = null
+)
+
+fun PlaceModel.asPlaceEntity(remoteId: String? = null, localId: Long = 0): PlaceEntity {
+    val (lat, lng, plan, caption, log) = this
+    return PlaceEntity(lat, lng, plan, caption, log, remoteId, localId)
+}
+
+fun PlaceModel.asPlaceDTO(remoteId: String? = null, localId: Long = 0): PlaceDTO {
+    val (lat, lng, plan, caption, log) = this
+    return PlaceDTO(lat, lng, plan, caption, log, remoteId, localId)
+}

--- a/app/src/main/java/com/treasurehunt/ui/savelog/SaveLogFragment.kt
+++ b/app/src/main/java/com/treasurehunt/ui/savelog/SaveLogFragment.kt
@@ -33,7 +33,6 @@ import com.treasurehunt.data.remote.model.PlaceDTO
 import com.treasurehunt.databinding.FragmentSavelogBinding
 import com.treasurehunt.ui.savelog.adapter.SaveLogAdapter
 import com.treasurehunt.util.showSnackbar
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.tasks.await
 import java.time.LocalDateTime
@@ -156,6 +155,9 @@ class SaveLogFragment : Fragment(), OnMapReadyCallback {
             viewLifecycleOwner.lifecycleScope.launch {
                 val localPlaceId = viewModel.insertPlace(placeEntity)
                 val remotePlaceId = viewModel.insertPlace(placeDTO)
+
+                viewModel.updatePlace(placeEntity.copy(id = localPlaceId, remoteId = remotePlaceId))
+
                 val createdDate = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
                     LocalDateTime.now().atZone(ZoneId.systemDefault()).toInstant().toEpochMilli()
                 } else {

--- a/app/src/main/java/com/treasurehunt/ui/savelog/SaveLogFragment.kt
+++ b/app/src/main/java/com/treasurehunt/ui/savelog/SaveLogFragment.kt
@@ -31,7 +31,7 @@ import com.treasurehunt.data.local.model.PlaceEntity
 import com.treasurehunt.data.remote.model.LogDTO
 import com.treasurehunt.data.remote.model.PlaceDTO
 import com.treasurehunt.databinding.FragmentSavelogBinding
-import com.treasurehunt.ui.home.MapSymbol
+import com.treasurehunt.ui.model.MapSymbol
 import com.treasurehunt.ui.savelog.adapter.SaveLogAdapter
 import com.treasurehunt.util.showSnackbar
 import kotlinx.coroutines.async

--- a/app/src/main/java/com/treasurehunt/ui/savelog/SaveLogFragment.kt
+++ b/app/src/main/java/com/treasurehunt/ui/savelog/SaveLogFragment.kt
@@ -216,7 +216,7 @@ class SaveLogFragment : Fragment(), OnMapReadyCallback {
         )
     }
 
-    private suspend fun getRemoteAndLocalPlaceIdFromPlanMarker(mapSymbol: MapSymbol): Pair<String, Long>? {
+    private suspend fun getPlaceId(mapSymbol: MapSymbol): Pair<String, Long>? {
         val remotePlaceId: String = mapSymbol.remoteId ?: return null
         val localPlaceId = viewModel.getRemotePlaceById(remotePlaceId).id
 
@@ -225,7 +225,7 @@ class SaveLogFragment : Fragment(), OnMapReadyCallback {
 
     private suspend fun insertPlace(mapSymbol: MapSymbol): String? {
         val place = mapSymbol.toPlace()
-        val (remotePlaceId, localPlaceId) = getRemoteAndLocalPlaceIdFromPlanMarker(mapSymbol)
+        val (remotePlaceId, localPlaceId) = getPlaceId(mapSymbol)
             ?: return null
         val remotePlace = viewModel.getRemotePlaceById(remotePlaceId)
 

--- a/app/src/main/java/com/treasurehunt/ui/savelog/SaveLogFragment.kt
+++ b/app/src/main/java/com/treasurehunt/ui/savelog/SaveLogFragment.kt
@@ -153,10 +153,19 @@ class SaveLogFragment : Fragment(), OnMapReadyCallback {
                 caption
             )
             viewLifecycleOwner.lifecycleScope.launch {
-                val localPlaceId = viewModel.insertPlace(placeEntity)
-                val remotePlaceId = viewModel.insertPlace(placeDTO)
-
-                viewModel.updatePlace(placeEntity.copy(id = localPlaceId, remoteId = remotePlaceId))
+                val remotePlaceId: String
+                val localPlaceId: Long
+                if (args.mapSymbol.isPlan) {
+                    remotePlaceId = args.mapSymbol.remoteId ?: return@launch
+                    val remotePlace = viewModel.getRemotePlaceById(remotePlaceId)
+                    localPlaceId = remotePlace.id
+                    viewModel.updatePlace(placeEntity.copy(id = localPlaceId, remoteId = remotePlaceId, plan = false))
+                    viewModel.updatePlace(remotePlaceId, remotePlace.copy(plan = false))
+                } else {
+                    remotePlaceId = viewModel.insertPlace(placeDTO)
+                    localPlaceId = viewModel.insertPlace(placeEntity)
+                    viewModel.updatePlace(placeEntity.copy(id = localPlaceId, remoteId = remotePlaceId))
+                }
 
                 val createdDate = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
                     LocalDateTime.now().atZone(ZoneId.systemDefault()).toInstant().toEpochMilli()

--- a/app/src/main/java/com/treasurehunt/ui/savelog/SaveLogFragment.kt
+++ b/app/src/main/java/com/treasurehunt/ui/savelog/SaveLogFragment.kt
@@ -1,10 +1,8 @@
 package com.treasurehunt.ui.savelog
 
 import android.content.pm.PackageManager
-import android.net.Uri
 import android.os.Build
 import android.os.Bundle
-import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -19,27 +17,25 @@ import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
 import com.google.firebase.Firebase
 import com.google.firebase.auth.auth
-import com.google.firebase.storage.storage
 import com.naver.maps.map.LocationTrackingMode
 import com.naver.maps.map.MapFragment
 import com.naver.maps.map.NaverMap
 import com.naver.maps.map.OnMapReadyCallback
 import com.naver.maps.map.util.FusedLocationSource
 import com.treasurehunt.R
-import com.treasurehunt.data.local.model.LogEntity
-import com.treasurehunt.data.local.model.PlaceEntity
-import com.treasurehunt.data.remote.model.LogDTO
 import com.treasurehunt.data.remote.model.PlaceDTO
 import com.treasurehunt.databinding.FragmentSavelogBinding
+import com.treasurehunt.ui.model.LogModel
 import com.treasurehunt.ui.model.MapSymbol
+import com.treasurehunt.ui.model.PlaceModel
+import com.treasurehunt.ui.model.asLogDTO
+import com.treasurehunt.ui.model.asLogEntity
+import com.treasurehunt.ui.model.asPlaceDTO
+import com.treasurehunt.ui.model.asPlaceEntity
 import com.treasurehunt.ui.savelog.adapter.SaveLogAdapter
+import com.treasurehunt.util.getCurrentTime
 import com.treasurehunt.util.showSnackbar
-import kotlinx.coroutines.async
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.tasks.await
-import java.time.LocalDateTime
-import java.time.ZoneId
-import java.util.Date
 
 class SaveLogFragment : Fragment(), OnMapReadyCallback {
 
@@ -68,7 +64,6 @@ class SaveLogFragment : Fragment(), OnMapReadyCallback {
         savedInstanceState: Bundle?
     ): View {
         _binding = FragmentSavelogBinding.inflate(inflater, container, false)
-
         return binding.root
     }
 
@@ -79,7 +74,7 @@ class SaveLogFragment : Fragment(), OnMapReadyCallback {
         initAdapter()
         setAlbumPermission()
         loadMap()
-        saveLog()
+        setSaveButton()
         setCancelButton()
     }
 
@@ -139,107 +134,113 @@ class SaveLogFragment : Fragment(), OnMapReadyCallback {
         }
     }
 
-    private fun saveLog() {
+    private fun setSaveButton() {
         binding.btnSave.setOnClickListener {
             viewLifecycleOwner.lifecycleScope.launch {
-                val (remotePlaceId, localPlaceId) = insertPlaceOrUpdatePlan(args.mapSymbol)
+                uploadImages()
 
-                val createdDate = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                    LocalDateTime.now().atZone(ZoneId.systemDefault()).toInstant().toEpochMilli()
-                } else {
-                    Date().time
-                }
-                val uid = Firebase.auth.currentUser!!.uid
+                val remotePlaceId = insertOrUpdatePlace(args.mapSymbol)
                 val text = binding.etText.text.toString()
                 val theme = "123"
-                val images: MutableList<String> = arrayListOf()
+                val createdDate = getCurrentTime()
 
-                for (i in 0 until viewModel.images.value.size) {
-                    uploadImage(
-                        i + 1,
-                        viewModel.images.value.size,
-                        uid,
-                        viewModel.images.value[i].url.toUri()
-                    )
-                }
-
-                // add to RemoteUser's logs & places // update & sync ids
-                viewModel.insertLog(LogEntity(remotePlaceId, images, text, theme, createdDate))
-                viewModel.insertLog(
-                    LogDTO(
-                        remotePlaceId,
-                        viewModel.imageUrl.value.associateWith { true },
-                        text,
-                        theme,
-                        createdDate
-                    )
+                val log = LogModel(
+                    remotePlaceId,
+                    viewModel.imageUrl.value,
+                    text,
+                    theme,
+                    createdDate
                 )
+                val remoteLogId = insertLog(log)
+
+                updateUser(remotePlaceId, remoteLogId)
+
                 findNavController().navigate(R.id.action_saveLogFragment_to_homeFragment)
             }
         }
     }
 
-    private suspend fun insertPlaceOrUpdatePlan(mapSymbol: MapSymbol): Pair<String, Long> {
-        val (lat, lng, caption) = mapSymbol
-        val placeEntity = PlaceEntity(
-            lat,
-            lng,
-            false,
-            caption
-        )
-        val placeDTO = PlaceDTO(
-            lat,
-            lng,
-            false,
-            caption
-        )
+    private suspend fun uploadImages() {
+        val uid = Firebase.auth.currentUser!!.uid
 
-        return viewLifecycleOwner.lifecycleScope.async {
-            val remotePlaceId: String
-            val remotePlace: PlaceDTO
-            val localPlaceId: Long
-
-            if (args.mapSymbol.isPlan) {
-                remotePlaceId = args.mapSymbol.remoteId!!
-                remotePlace = viewModel.getRemotePlaceById(remotePlaceId)
-                localPlaceId = remotePlace.id
-                viewModel.updatePlace(
-                    placeEntity.copy(
-                        id = localPlaceId,
-                        remoteId = remotePlaceId,
-                        plan = false
+        for (i in 0 until viewModel.images.value.size) {
+            val result = viewModel.uploadImage(
+                i + 1,
+                viewModel.images.value.size,
+                uid,
+                viewModel.images.value[i].url.toUri()
+            )
+            if (result) {
+                binding.root.showSnackbar(
+                    getString(
+                        R.string.savelog_sb_upload_success,
+                        i + 1,
+                        viewModel.images.value.size
                     )
                 )
-                viewModel.updatePlace(remotePlaceId, remotePlace.copy(plan = false))
             } else {
-                remotePlaceId = viewModel.insertPlace(placeDTO)
-                localPlaceId = viewModel.insertPlace(placeEntity)
-                viewModel.updatePlace(placeEntity.copy(id = localPlaceId, remoteId = remotePlaceId))
+                binding.root.showSnackbar(R.string.savelog_sb_upload_failure)
             }
-
-            return@async (remotePlaceId to localPlaceId)
-        }.await()
+        }
     }
 
-    private suspend fun uploadImage(currentCount: Int, maxCount: Int, uid: String, uri: Uri) {
-        val storage = Firebase.storage
-        val storageRef = storage.getReference("${uid}/log_images")
-        val fileName = uri.toString().replace("[^0-9]".toRegex(), "")
-        val mountainsRef = storageRef.child("${fileName}.png")
-        val uploadTask = mountainsRef.putFile(uri)
-        uploadTask.addOnSuccessListener { taskSnapshot ->
-            viewModel.addImageUrl(taskSnapshot.storage.toString())
-            binding.root.showSnackbar(
-                getString(
-                    R.string.savelog_sb_upload_success,
-                    currentCount,
-                    maxCount
+    private suspend fun insertLog(log: LogModel): String {
+        viewModel.insertLog(log.asLogEntity())
+        return viewModel.insertLog(log.asLogDTO())
+    }
+
+    private suspend fun updateUser(remotePlaceId: String, remoteLogId: String) {
+        val uid = Firebase.auth.currentUser!!.uid
+        val userDTO = viewModel.getUserById(uid)
+        if (args.mapSymbol.isPlan) {
+            viewModel.updateUser(
+                uid, userDTO.copy(plans = userDTO.plans.minus(remotePlaceId))
+            )
+        }
+        viewModel.updateUser(
+            uid,
+            userDTO.copy(
+                places = userDTO.places.plus(remotePlaceId to true),
+                logs = userDTO.logs.plus(remoteLogId to true)
+            )
+        )
+    }
+
+    private suspend fun insertOrUpdatePlace(mapSymbol: MapSymbol): String {
+        val (lat, lng, caption) = mapSymbol
+        val place = PlaceModel(
+            lat,
+            lng,
+            false,
+            caption
+        )
+
+        val remotePlaceId: String
+        val remotePlace: PlaceDTO
+        val localPlaceId: Long
+
+        if (args.mapSymbol.isPlan) {
+            remotePlaceId = args.mapSymbol.remoteId!!
+            remotePlace = viewModel.getRemotePlaceById(remotePlaceId)
+            localPlaceId = remotePlace.id
+            viewModel.updatePlace(
+                place.asPlaceEntity(remotePlaceId, localPlaceId)
+                    .copy(plan = false)
+            )
+            viewModel.updatePlace(
+                remotePlaceId, remotePlace.copy(plan = false)
+            )
+        } else {
+            remotePlaceId = viewModel.insertPlace(place.asPlaceDTO())
+            localPlaceId = viewModel.insertPlace(place.asPlaceEntity())
+            viewModel.updatePlace(
+                place.asPlaceEntity(remotePlaceId).copy(
+                    id = localPlaceId
                 )
             )
-        }.addOnFailureListener {
-            binding.root.showSnackbar(R.string.savelog_sb_upload_failure)
         }
-        uploadTask.await()
+
+        return remotePlaceId
     }
 
     private fun setLocationTrackingMode(isGranted: Boolean) {

--- a/app/src/main/java/com/treasurehunt/ui/savelog/SaveLogFragment.kt
+++ b/app/src/main/java/com/treasurehunt/ui/savelog/SaveLogFragment.kt
@@ -139,7 +139,7 @@ class SaveLogFragment : Fragment(), OnMapReadyCallback {
 
     private fun saveLog() {
         binding.btnSave.setOnClickListener {
-            val (lat, lng, caption) = args.MapSymbol
+            val (lat, lng, caption) = args.mapSymbol
             val placeEntity = PlaceEntity(
                 lat,
                 lng,

--- a/app/src/main/java/com/treasurehunt/ui/savelog/SaveLogFragment.kt
+++ b/app/src/main/java/com/treasurehunt/ui/savelog/SaveLogFragment.kt
@@ -234,10 +234,9 @@ class SaveLogFragment : Fragment(), OnMapReadyCallback {
             remotePlaceId = viewModel.insertPlace(place.asPlaceDTO())
             localPlaceId = viewModel.insertPlace(place.asPlaceEntity())
             viewModel.updatePlace(
-                place.asPlaceEntity(remotePlaceId).copy(
-                    id = localPlaceId
-                )
+                place.asPlaceEntity(remotePlaceId, localPlaceId)
             )
+            viewModel.updatePlace(remotePlaceId, place.asPlaceDTO(remotePlaceId, localPlaceId))
         }
 
         return remotePlaceId

--- a/app/src/main/java/com/treasurehunt/ui/savelog/SaveLogViewModel.kt
+++ b/app/src/main/java/com/treasurehunt/ui/savelog/SaveLogViewModel.kt
@@ -16,6 +16,7 @@ import com.treasurehunt.data.remote.model.PlaceDTO
 import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
 
 class SaveLogViewModel(
     private val logRepo: LogRepository,
@@ -80,6 +81,10 @@ class SaveLogViewModel(
         return viewModelScope.async {
             placeRepo.insert(placeDTO)
         }.await()
+    }
+
+    suspend fun updatePlace(place: PlaceEntity) {
+        placeRepo.update(place)
     }
 
     companion object {

--- a/app/src/main/java/com/treasurehunt/ui/savelog/SaveLogViewModel.kt
+++ b/app/src/main/java/com/treasurehunt/ui/savelog/SaveLogViewModel.kt
@@ -83,8 +83,18 @@ class SaveLogViewModel(
         }.await()
     }
 
+    suspend fun getRemotePlaceById(id: String): PlaceDTO {
+        return viewModelScope.async {
+            return@async placeRepo.getRemotePlace(id)
+        }.await()
+    }
+
     suspend fun updatePlace(place: PlaceEntity) {
         placeRepo.update(place)
+    }
+
+    suspend fun updatePlace(id: String, place: PlaceDTO) {
+        placeRepo.update(id, place)
     }
 
     companion object {

--- a/app/src/main/java/com/treasurehunt/ui/savelog/SaveLogViewModel.kt
+++ b/app/src/main/java/com/treasurehunt/ui/savelog/SaveLogViewModel.kt
@@ -3,6 +3,7 @@ package com.treasurehunt.ui.savelog
 import android.content.Intent
 import android.net.Uri
 import android.provider.MediaStore
+import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
@@ -52,8 +53,9 @@ class SaveLogViewModel(
             }.addOnFailureListener {
                 result = false
             }
-            uploadTask.await()
-            result
+//            uploadTask.await() //  retrofit2.HttpException: HTTP 400 Bad Request 오류 발생
+
+            return@async result
         }.await()
     }
 

--- a/app/src/main/java/com/treasurehunt/ui/savelog/SaveLogViewModel.kt
+++ b/app/src/main/java/com/treasurehunt/ui/savelog/SaveLogViewModel.kt
@@ -9,7 +9,6 @@ import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.CreationExtras
 import com.google.firebase.Firebase
 import com.google.firebase.storage.storage
-import com.treasurehunt.R
 import com.treasurehunt.TreasureHuntApplication
 import com.treasurehunt.data.LogRepository
 import com.treasurehunt.data.PlaceRepository
@@ -19,11 +18,9 @@ import com.treasurehunt.data.local.model.PlaceEntity
 import com.treasurehunt.data.remote.model.LogDTO
 import com.treasurehunt.data.remote.model.PlaceDTO
 import com.treasurehunt.data.remote.model.UserDTO
-import com.treasurehunt.util.showSnackbar
 import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.tasks.await
 
 class SaveLogViewModel(

--- a/app/src/main/java/com/treasurehunt/ui/savelog/SaveLogViewModel.kt
+++ b/app/src/main/java/com/treasurehunt/ui/savelog/SaveLogViewModel.kt
@@ -4,15 +4,22 @@ import android.content.Intent
 import android.provider.MediaStore
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.CreationExtras
 import com.treasurehunt.TreasureHuntApplication
 import com.treasurehunt.data.LogRepository
+import com.treasurehunt.data.PlaceRepository
+import com.treasurehunt.data.local.model.LogEntity
+import com.treasurehunt.data.local.model.PlaceEntity
 import com.treasurehunt.data.remote.model.LogDTO
+import com.treasurehunt.data.remote.model.PlaceDTO
+import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 
 class SaveLogViewModel(
     private val logRepo: LogRepository,
+    private val placeRepo: PlaceRepository
 ) : ViewModel() {
 
     private val _images: MutableStateFlow<List<ImageModel>> = MutableStateFlow(emptyList())
@@ -40,6 +47,10 @@ class SaveLogViewModel(
         setButtonState()
     }
 
+    suspend fun insertLog(logEntity: LogEntity) {
+        logRepo.insert(logEntity)
+    }
+
     suspend fun insertLog(logDTO: LogDTO) {
         logRepo.insert(logDTO)
     }
@@ -59,6 +70,18 @@ class SaveLogViewModel(
         return _isEnabled.value
     }
 
+    suspend fun insertPlace(placeEntity: PlaceEntity): Long {
+        return viewModelScope.async {
+            placeRepo.insert(placeEntity)
+        }.await()
+    }
+
+    suspend fun insertPlace(placeDTO: PlaceDTO): String {
+        return viewModelScope.async {
+            placeRepo.insert(placeDTO)
+        }.await()
+    }
+
     companion object {
         val Factory: ViewModelProvider.Factory = object : ViewModelProvider.Factory {
             override fun <T : ViewModel> create(
@@ -66,7 +89,8 @@ class SaveLogViewModel(
                 extras: CreationExtras
             ): T {
                 return SaveLogViewModel(
-                    TreasureHuntApplication.logRepo
+                    TreasureHuntApplication.logRepo,
+                    TreasureHuntApplication.placeRepo
                 ) as T
             }
         }

--- a/app/src/main/java/com/treasurehunt/util/ConnectivityRepository.kt
+++ b/app/src/main/java/com/treasurehunt/util/ConnectivityRepository.kt
@@ -1,0 +1,35 @@
+package com.treasurehunt.util
+
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.Network
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+
+class ConnectivityRepository(context: Context) {
+    private val _isConnected = MutableStateFlow(false)
+    val isConnected: Flow<Boolean> = _isConnected
+    private val connectivityManager = context.getSystemService(ConnectivityManager::class.java)
+    private val networkCallback = object :
+        ConnectivityManager.NetworkCallback() {
+        override fun onAvailable(network: Network) {
+            super.onAvailable(network)
+
+            _isConnected.value = true
+        }
+
+        override fun onLost(network: Network) {
+            super.onLost(network)
+
+            _isConnected.value = false
+        }
+    }
+
+    init {
+        connectivityManager.registerDefaultNetworkCallback(networkCallback)
+    }
+
+    fun release() {
+        connectivityManager.unregisterNetworkCallback(networkCallback)
+    }
+}

--- a/app/src/main/java/com/treasurehunt/util/Functions.kt
+++ b/app/src/main/java/com/treasurehunt/util/Functions.kt
@@ -1,0 +1,12 @@
+package com.treasurehunt.util
+
+import android.os.Build
+import java.time.LocalDateTime
+import java.time.ZoneId
+import java.util.Date
+
+fun getCurrentTime() = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+    LocalDateTime.now().atZone(ZoneId.systemDefault()).toInstant().toEpochMilli()
+} else {
+    Date().time
+}

--- a/app/src/main/res/layout/fragment_map_dialog.xml
+++ b/app/src/main/res/layout/fragment_map_dialog.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".ui.home.MapDialogFragment">
+
+    <TextView
+        android:id="@+id/tv_title"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="20dp"
+        android:gravity="center"
+        android:text="이 장소를 보물상자로 지정할까요?"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <androidx.constraintlayout.helper.widget.Flow
+        android:id="@+id/flow_btns"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="40dp"
+        android:orientation="vertical"
+        app:constraint_referenced_ids="btn_place,btn_plan,btn_cancel"
+        app:flow_verticalGap="10dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/tv_title" />
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/btn_place"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="네, 가봤어요" />
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/btn_plan"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="네, 가볼래요" />
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/btn_cancel"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="아니요" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_map_dialog.xml
+++ b/app/src/main/res/layout/fragment_map_dialog.xml
@@ -12,7 +12,7 @@
         android:layout_height="wrap_content"
         android:layout_marginTop="20dp"
         android:gravity="center"
-        android:text="이 장소를 보물상자로 지정할까요?"
+        android:text="@string/map_prompt"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
@@ -33,17 +33,17 @@
         android:id="@+id/btn_place"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="네, 가봤어요" />
+        android:text="@string/map_answer_place" />
 
     <com.google.android.material.button.MaterialButton
         android:id="@+id/btn_plan"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="네, 가볼래요" />
+        android:text="@string/map_answer_plan" />
 
     <com.google.android.material.button.MaterialButton
         android:id="@+id/btn_cancel"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="아니요" />
+        android:text="@string/map_answer_no" />
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -79,6 +79,9 @@
         <action
             android:id="@+id/action_detailFragment_to_saveLogFragment"
             app:destination="@id/saveLogFragment" />
+        <argument
+            android:name="remotePlaceId"
+            app:argType="string" />
     </dialog>
 
     <fragment

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -59,6 +59,12 @@
         <action
             android:id="@+id/action_saveLogFragment_to_saveLogMapFragment"
             app:destination="@id/saveLogMapFragment" />
+        <action
+            android:id="@+id/action_saveLogFragment_to_homeFragment"
+            app:destination="@id/homeFragment" />
+        <argument
+            android:name="MapSymbol"
+            app:argType="com.treasurehunt.ui.home.MapSymbol" />
     </fragment>
 
     <fragment
@@ -91,6 +97,9 @@
         <action
             android:id="@+id/action_mapDialogFragment_to_homeFragment"
             app:destination="@id/homeFragment" />
+        <action
+            android:id="@+id/action_mapDialogFragment_to_saveLogFragment"
+            app:destination="@id/saveLogFragment" />
         <argument
             android:name="MapSymbol"
             app:argType="com.treasurehunt.ui.home.MapSymbol" />

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -69,7 +69,7 @@
             app:argType="string" />
         <argument
             android:name="mapSymbol"
-            app:argType="com.treasurehunt.ui.home.MapSymbol" />
+            app:argType="com.treasurehunt.ui.model.MapSymbol" />
     </fragment>
 
     <fragment
@@ -109,6 +109,6 @@
             app:argType="string" />
         <argument
             android:name="mapSymbol"
-            app:argType="com.treasurehunt.ui.home.MapSymbol" />
+            app:argType="com.treasurehunt.ui.model.MapSymbol" />
     </dialog>
 </navigation>

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -48,6 +48,9 @@
         <action
             android:id="@+id/action_homeFragment_to_detailFragment"
             app:destination="@id/detailFragment" />
+        <argument
+            android:name="uid"
+            app:argType="string" />
     </fragment>
 
     <fragment
@@ -62,7 +65,10 @@
             android:id="@+id/action_saveLogFragment_to_homeFragment"
             app:destination="@id/homeFragment" />
         <argument
-            android:name="MapSymbol"
+            android:name="uid"
+            app:argType="string" />
+        <argument
+            android:name="mapSymbol"
             app:argType="com.treasurehunt.ui.home.MapSymbol" />
     </fragment>
 
@@ -91,7 +97,7 @@
         android:id="@+id/mapDialogFragment"
         android:name="com.treasurehunt.ui.home.MapDialogFragment"
         android:label="fragment_map_dialog"
-        tools:layout="@layout/fragment_map_dialog" >
+        tools:layout="@layout/fragment_map_dialog">
         <action
             android:id="@+id/action_mapDialogFragment_to_homeFragment"
             app:destination="@id/homeFragment" />
@@ -99,7 +105,10 @@
             android:id="@+id/action_mapDialogFragment_to_saveLogFragment"
             app:destination="@id/saveLogFragment" />
         <argument
-            android:name="MapSymbol"
+            android:name="uid"
+            app:argType="string" />
+        <argument
+            android:name="mapSymbol"
             app:argType="com.treasurehunt.ui.home.MapSymbol" />
     </dialog>
 </navigation>

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -32,7 +32,6 @@
             app:destination="@id/homeFragment"
             app:popUpTo="@id/logInFragment"
             app:popUpToInclusive="true" />
-
     </fragment>
 
     <fragment

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -48,9 +48,6 @@
         <action
             android:id="@+id/action_homeFragment_to_detailFragment"
             app:destination="@id/detailFragment" />
-        <argument
-            android:name="uid"
-            app:argType="string" />
     </fragment>
 
     <fragment
@@ -64,9 +61,6 @@
         <action
             android:id="@+id/action_saveLogFragment_to_homeFragment"
             app:destination="@id/homeFragment" />
-        <argument
-            android:name="uid"
-            app:argType="string" />
         <argument
             android:name="mapSymbol"
             app:argType="com.treasurehunt.ui.model.MapSymbol" />
@@ -104,9 +98,6 @@
         <action
             android:id="@+id/action_mapDialogFragment_to_saveLogFragment"
             app:destination="@id/saveLogFragment" />
-        <argument
-            android:name="uid"
-            app:argType="string" />
         <argument
             android:name="mapSymbol"
             app:argType="com.treasurehunt.ui.model.MapSymbol" />

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -41,6 +41,9 @@
         android:label="fragment_home"
         tools:layout="@layout/fragment_home">
         <action
+            android:id="@+id/action_homeFragment_to_mapDialogFragment"
+            app:destination="@id/mapDialogFragment" />
+        <action
             android:id="@+id/action_homeFragment_to_saveLogFragment"
             app:destination="@id/saveLogFragment" />
         <action
@@ -72,10 +75,25 @@
             android:id="@+id/action_detailFragment_to_saveLogFragment"
             app:destination="@id/saveLogFragment" />
     </dialog>
+<<<<<<< HEAD
 
     <fragment
         android:id="@+id/profileFragment"
         android:name="com.treasurehunt.ui.profile.ProfileFragment"
         android:label="ProfileFragment"
         tools:layout="@layout/fragment_profile" />
+=======
+    <dialog
+        android:id="@+id/mapDialogFragment"
+        android:name="com.treasurehunt.ui.home.MapDialogFragment"
+        android:label="fragment_map_dialog"
+        tools:layout="@layout/fragment_map_dialog" >
+        <action
+            android:id="@+id/action_mapDialogFragment_to_homeFragment"
+            app:destination="@id/homeFragment" />
+        <argument
+            android:name="MapSymbol"
+            app:argType="com.treasurehunt.ui.home.MapSymbol" />
+    </dialog>
+>>>>>>> d71dc85 (feat: 홈 지도 화면 장소 클릭시 다이얼로그 표시 구현)
 </navigation>

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -81,14 +81,13 @@
             android:id="@+id/action_detailFragment_to_saveLogFragment"
             app:destination="@id/saveLogFragment" />
     </dialog>
-<<<<<<< HEAD
 
     <fragment
         android:id="@+id/profileFragment"
         android:name="com.treasurehunt.ui.profile.ProfileFragment"
         android:label="ProfileFragment"
         tools:layout="@layout/fragment_profile" />
-=======
+
     <dialog
         android:id="@+id/mapDialogFragment"
         android:name="com.treasurehunt.ui.home.MapDialogFragment"
@@ -104,5 +103,4 @@
             android:name="MapSymbol"
             app:argType="com.treasurehunt.ui.home.MapSymbol" />
     </dialog>
->>>>>>> d71dc85 (feat: 홈 지도 화면 장소 클릭시 다이얼로그 표시 구현)
 </navigation>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -40,4 +40,5 @@
     <string name="profile_tl_comment">댓글</string>
     <string name="profile_tl_tag">태그</string>
     <string name="profile_check_url">https://</string>
+    <string name="savelog_sb_save_failure">문제가 생겨 기록을 저장할 수 없습니다.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -9,6 +9,12 @@
     <string name="home_map">지도</string>
     <string name="home_feed">피드</string>
 
+    <!-- 지도 다이얼로그 -->
+    <string name="map_prompt">%1$s를 보물상자로 지정할까요?</string>
+    <string name="map_answer_place">네, 가봤어요</string>
+    <string name="map_answer_plan">네, 가볼래요</string>
+    <string name="map_answer_no">아니요</string>
+
     <!-- 로그인 화면 -->
     <string name="login_naver">네이버로 계속하기</string>
     <string name="login_non_member">비회원으로 로그인</string>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,5 +9,6 @@ plugins {
 buildscript {
     dependencies {
         classpath("org.jetbrains.kotlin:kotlin-serialization:1.9.22")
+        classpath("androidx.navigation:navigation-safe-args-gradle-plugin:2.7.6")
     }
 }


### PR DESCRIPTION
** 2+ 브랜치 작업량을 한 브랜치에서 계속 작업해버리는 큰 실수를 해서 리뷰하기 힘드실 텐데 다시 한번 양해 부탁드립니다

홈 지도 화면
- [x] 장소 클릭시 다이얼로그 표시
- [x] 네트워크 연결 콜백 레포지토리 추가 및 홈 뷰모델에서 연결 상태 관리

홈 지도 화면 다이얼로그
- [x] "네, 가봤어요" 클릭시, 기록 저장 화면으로 이동
- [x] "네, 가볼래요" 클릭시, 장소를 plan = true로 로컬, 원격 DB에 추가
- [x] "아니오" 클릭시, 뒤로가기 

기록 저장 화면
- [x] 확인 버튼 클릭시, plan인 장소의 경우 (닫힌 보물상자 마커 클릭을 통해 현재 화면에 유입), 장소를 plan = false로 로컬, 원격 DB에 업데이트
- [x] 확인 버튼 클릭시, plan이 아닌 장소의 경우 (마커가 없는 지도 심볼 클릭을 통해 현재 화면에 유입), 장소를 로컬, 원격 DB에 추가
- [x] 확인 버튼 클릭시, 기록을 로컬, 원격 DB에 추가
- [x] 확인 버튼 클릭시, 유저를 place, plan, log에 대해 원격 DB에 업데이트

데이터 클래스 관련
- [x] Place, Log에 대해 UI 레이어용 Model 객체 추가

피드백 반영
- [x] 닫힌 보물 상자 마커 클릭 후 기록 저장 화면으로 이동한 다음, 취소 버튼 클릭해 이전 홈 화면으로 이동시에 uid 값이 없어서 마커 표시가 안 되는 오류 해결 -> 홈 지도 화면, 지도 다이얼로그, 기록 저장 화면에서 uid 관리 방식 수정 (navArgs로 전달 -> Firebase.auth로 접근)
- [x] 기록 상세 화면 편집 버튼 클릭시 강종 오류 해결 -> 내비게이션 출발지 변경
- [x] fix: 홈 지도 화면에서 열린 보물상자 마커 클릭해 기록 상세화면으로 이동후 편집 버튼 클릭해 기록 저장화면으로 이동후 취소 버튼 클릭해 다시 홈 지도 화면으로 이동시, 보물상자 마커들이 표시되지 않는 오류 해결  -> 홈 뷰모델에서 로컬 장소 데이터 수집시, merge -> combine 함수 변경 & stateIn 함수 추가해 StateFlow 타입 유지