### PR TITLE
refactor: 로그인 화면 로직 수정, 에러 스낵바 추가, 기타 리팩토링

### DIFF
--- a/app/src/main/java/com/treasurehunt/ui/login/LogInFragment.kt
+++ b/app/src/main/java/com/treasurehunt/ui/login/LogInFragment.kt
@@ -72,7 +72,6 @@ class LogInFragment : Fragment() {
                 }
 
                 override fun onFailure(httpStatus: Int, message: String) {
-
                 }
 
                 override fun onError(errorCode: Int, message: String) {
@@ -94,7 +93,7 @@ class LogInFragment : Fragment() {
                     naverProfile.profileImage
                 )
 
-                createAccount(user)
+                loginAccount(user)
             }
 
             override fun onFailure(httpStatus: Int, message: String) {
@@ -113,7 +112,7 @@ class LogInFragment : Fragment() {
                 if (task.isSuccessful) {
                     lifecycleScope.launch {
                         viewModel.insertNaverUser(user)
-                        loginAccount(user)
+                        findNavController().navigate(R.id.action_logInFragment_to_homeFragment)
                     }
                 } else {
                     binding.root.showSnackbar(R.string.login_create_account_error)
@@ -130,7 +129,7 @@ class LogInFragment : Fragment() {
                         findNavController().navigate(R.id.action_logInFragment_to_homeFragment)
                     }
                 } else {
-                    binding.root.showSnackbar(R.string.login_naver_login_error)
+                    createAccount(user)
                 }
             }
     }

--- a/app/src/main/java/com/treasurehunt/ui/login/LoginViewModel.kt
+++ b/app/src/main/java/com/treasurehunt/ui/login/LoginViewModel.kt
@@ -32,7 +32,7 @@ class LoginViewModel(
         val userDTO = UserDTO(
             email = currentUser.email,
             nickname = currentUser.displayName,
-            profileImage = currentUser.photoUrl?.path
+            profileImage = currentUser.photoUrl?.toString()
         )
         userRepo.insert(currentUser.uid, userDTO)
     }
@@ -72,7 +72,7 @@ class LoginViewModel(
         placeRepo.deleteAll()
         userDTO.places.map {
             val place = placeRepo.getRemotePlace(it.key)
-            placeRepo.insert(place.toPlaceEntity())
+            placeRepo.insert(place.toPlaceEntity(it.key))
         }
     }
 

--- a/app/src/main/java/com/treasurehunt/ui/login/LoginViewModel.kt
+++ b/app/src/main/java/com/treasurehunt/ui/login/LoginViewModel.kt
@@ -20,30 +20,29 @@ import kotlinx.coroutines.delay
 const val USER_UPDATE_DELAY = 1000L
 
 class LoginViewModel(
-    private val userRepository: UserRepository,
-    private val logRepository: LogRepository,
-    private val placeRepository: PlaceRepository
+    private val userRepo: UserRepository,
+    private val logRepo: LogRepository,
+    private val placeRepo: PlaceRepository
 ) : ViewModel() {
 
     suspend fun insertNaverUser(user: User) {
         updateProfile(user)
         delay(USER_UPDATE_DELAY)
         val currentUser = Firebase.auth.currentUser!!
-        // 테스트 샘플
         val userDTO = UserDTO(
             email = currentUser.email,
             nickname = currentUser.displayName,
-            profileImage = currentUser.photoUrl.toString()
+            profileImage = currentUser.photoUrl?.path
         )
-        userRepository.insert(currentUser.uid, userDTO)
+        userRepo.insert(currentUser.uid, userDTO)
     }
 
     suspend fun insertGuestUser() {
         val currentUser = Firebase.auth.currentUser!!
         val userDTO = UserDTO(
-            email = currentUser.email ?: ""
+            email = ""
         )
-        userRepository.insert(currentUser.uid, userDTO)
+        userRepo.insert(currentUser.uid, userDTO)
     }
 
     private fun updateProfile(user: User) {
@@ -56,24 +55,24 @@ class LoginViewModel(
 
     suspend fun initLocalData() {
         val curUserUid = Firebase.auth.currentUser!!.uid
-        val userDTO = userRepository.getRemoteUser(curUserUid)
+        val userDTO = userRepo.getRemoteUser(curUserUid)
         initLocalLogs(userDTO)
-//            castingRemotePlaces(userDTO)
+        initLocalPlaces(userDTO)
     }
 
     private suspend fun initLocalLogs(userDTO: UserDTO) {
-        logRepository.deleteAll()
+        logRepo.deleteAll()
         userDTO.logs.map {
-            val log = logRepository.getRemoteLog(it.key)
-            logRepository.insert(log.toLogEntity(it.key))
+            val log = logRepo.getRemoteLog(it.key)
+            logRepo.insert(log.toLogEntity(it.key))
         }
     }
 
     private suspend fun initLocalPlaces(userDTO: UserDTO) {
-        placeRepository.deleteAll()
+        placeRepo.deleteAll()
         userDTO.places.map {
-            val place = placeRepository.getRemotePlace(it.key)
-            placeRepository.insert(place.toPlaceEntity(it.key))
+            val place = placeRepo.getRemotePlace(it.key)
+            placeRepo.insert(place.toPlaceEntity())
         }
     }
 

--- a/app/src/main/java/com/treasurehunt/ui/login/SplashFragment.kt
+++ b/app/src/main/java/com/treasurehunt/ui/login/SplashFragment.kt
@@ -1,4 +1,5 @@
 package com.treasurehunt.ui.login
+
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -13,12 +14,11 @@ import com.treasurehunt.R
 import com.treasurehunt.databinding.FragmentSplashBinding
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+
 class SplashFragment : Fragment() {
     private var _binding: FragmentSplashBinding? = null
     private val binding get() = _binding!!
-
     private val viewModel: LoginViewModel by viewModels { LoginViewModel.Factory }
-
     private var isInitialized = false
 
     override fun onCreateView(
@@ -28,6 +28,7 @@ class SplashFragment : Fragment() {
         _binding = FragmentSplashBinding.inflate(inflater, container, false)
         return binding.root
     }
+
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         initSplashScreen()
@@ -44,6 +45,7 @@ class SplashFragment : Fragment() {
         super.onDestroyView()
         _binding = null
     }
+
     private fun initSplashScreen() {
         binding.animationView.setAnimation(R.raw.iv_treasure)
         binding.animationView.playAnimation()

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -19,6 +19,9 @@
     <string name="login_naver">네이버로 계속하기</string>
     <string name="login_non_member">비회원으로 로그인</string>
     <string name="login_treasure_hunt">보물찾기</string>
+    <string name="login_naver_login_error">네이버 로그인 실패. 잠시 후 다시 시도해 주세요.</string>
+    <string name="login_create_account_error">회원가입 실패. 잠시 후 다시 시도해 주세요.</string>
+    <string name="login_guest_login_error">비회원 로그인 실패. 잠시 후 다시 시도해 주세요.</string>
 
     <!-- 기록 저장 화면 -->
     <string name="savelog_tv_title">내 추억</string>


### PR DESCRIPTION
네이버 로그인 튕기는 오류 디버깅하는 도중에, LoginFragment 로직 이해 안 되는 부분들 좀 수정했습니다

1) 기존에는 네이버 로그인시, loginAccount 함수를 호출하고 실패하는 경우, createAccount 함수를 호출했는데, 이는 적절한 실패 처리라고 생각되지 않습니다. 파이어베이스 공식 문서에도 task가 실패한 경우에는 에러 메시지를 로그로 출력하는 처리 등을 하고 있습니다.
그래서 구현 순서를 createAccount -> loginAccount로 수정했고, 실패 처리는 오류 메시지 스낵바로 구현했습니다.

https://firebase.google.com/docs/auth/android/email-link-auth

`Firebase.auth.currentUser!!.linkWithCredential(credential)
    .addOnCompleteListener { task ->
        if (task.isSuccessful) {
            Log.d(TAG, "Successfully linked emailLink credential!")
            val result = task.result
        } else {
            Log.e(TAG, "Error linking emailLink credential", task.exception)
        }
    }`

--> 동현님 답글대로 원래 로직이 맞네요. 그럼 이 브랜치는 그냥 간단한 리팩토링으로 봐주시면 감사하겠습니다

2) 프래그먼트의 함수명을 loginNaverAccount -> fetchNaverAccount 수정했습니다. 해당 함수의 주기능은 callProfileApi 함수를 호출해서 네이버 계정 정보를 불러오는 것이며 로그인과는 무관하게 보여 코드를 해석하는 데 혼란을 야기한다고 판단해 수정했습니다.

나머지는 자잘한 리팩토링입니다

다들 코드 리뷰 부탁드리는데, 특히 동현님은 수정사항에 대해 이해 안 되거나 이상한 부분 있으시면 알려주세요~