### PR TITLE
fix: 홈 지도 화면에서 삭제된 기록의 장소에 대한 마커 숨김 처리

### DIFF
--- a/app/src/main/java/com/treasurehunt/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/treasurehunt/ui/home/HomeFragment.kt
@@ -148,14 +148,22 @@ class HomeFragment : Fragment(), OnMapReadyCallback {
                 viewModel.uiState.collect { uiState ->
                     if (uiState.uid == null) return@collect
 
-                    uiState.visitMarkers.forEach { marker ->
-                        marker.show()
-                        marker.setVisitClick()
+                    uiState.visitMarkers.forEach { markerEntry ->
+                        if (markerEntry.value) {
+                            markerEntry.key.show()
+                            markerEntry.key.setVisitClick()
+                        } else {
+                            markerEntry.key.hide()
+                        }
                     }
 
-                    uiState.planMarkers.forEach { marker ->
-                        marker.show()
-                        marker.setPlanClick()
+                    uiState.planMarkers.forEach { markerEntry ->
+                        if (markerEntry.value) {
+                            markerEntry.key.show()
+                            markerEntry.key.setPlanClick()
+                        } else {
+                            markerEntry.key.hide()
+                        }
                     }
                 }
             }
@@ -164,6 +172,10 @@ class HomeFragment : Fragment(), OnMapReadyCallback {
 
     private fun Marker.show() {
         map = this@HomeFragment.map
+    }
+
+    private fun Marker.hide() {
+        map = null
     }
 
     private fun Marker.setVisitClick() {

--- a/app/src/main/java/com/treasurehunt/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/treasurehunt/ui/home/HomeViewModel.kt
@@ -109,10 +109,19 @@ class HomeViewModel @Inject constructor(
                     .stateIn(viewModelScope, SharingStarted.WhileSubscribed(), emptyList())
                     .collect { visitsAndPlans ->
                         _uiState.update { uiState ->
+                            val oldVisitMarkers = uiState.visitMarkers.filterValues { true }
+                            val oldPlanMarkers = uiState.planMarkers.filterValues { true }
                             val (visits, plans) = visitsAndPlans.partition { !it.plan }
+                            val newVisitMarkers = visits.mapToMarkers().associateWith { true }
+                            val newPlanMarkers = plans.mapToMarkers().associateWith { true }
+                            val removedVisitMarkers = oldVisitMarkers.minus(newVisitMarkers.keys)
+                                .mapValues { false }
+                            val removedPlanMarkers = oldPlanMarkers.minus(newPlanMarkers.keys)
+                                .mapValues { false }
+
                             uiState.copy(
-                                visitMarkers = visits.mapToMarkers(),
-                                planMarkers = plans.mapToMarkers()
+                                visitMarkers = newVisitMarkers + removedVisitMarkers,
+                                planMarkers = newPlanMarkers + removedPlanMarkers
                             )
                         }
                     }

--- a/app/src/main/java/com/treasurehunt/ui/model/MapUiState.kt
+++ b/app/src/main/java/com/treasurehunt/ui/model/MapUiState.kt
@@ -5,9 +5,7 @@ import com.treasurehunt.data.local.model.PlaceEntity
 
 data class MapUiState(
     val uid: String? = null,
-    val visits: List<PlaceEntity> = listOf(),
-    val plans: List<PlaceEntity> = listOf(),
-    val visitMarkers: List<Marker> = listOf(),
-    val planMarkers: List<Marker> = listOf(),
+    val visitMarkers: Map<Marker, Boolean> = mapOf(),
+    val planMarkers: Map<Marker, Boolean> = mapOf(),
     val isOnline: Boolean = false
 )


### PR DESCRIPTION
- [x] MapUiState가 관리하는 마커 데이터 타입을 List -> Map으로 변경하여, 삭제된 기록의 장소 데이터도 추가적으로 관리해 마커 숨김 처리

** 준수님 기록 상세 화면 PR 머지하시고, 이 브랜치 머지하겠습니다 (준수님 브랜치에 이 작업 내용 추가한 결과, 마커 삭제되는 거 확인했습니다)