### PR TITLE
refactor: DB 관련 함수들 이름, 순서 통일 및 불필요한 함수들 삭제

### DIFF
--- a/app/src/main/java/com/treasurehunt/data/ImageRepository.kt
+++ b/app/src/main/java/com/treasurehunt/data/ImageRepository.kt
@@ -5,9 +5,9 @@ import com.treasurehunt.data.remote.model.ImageDTO
 
 interface ImageRepository {
 
-    suspend fun insertImage(imageEntity: ImageEntity): Long
+    suspend fun insert(imageEntity: ImageEntity): Long
 
-    suspend fun insertImage(imageDTO: ImageDTO): String
+    suspend fun insert(imageDTO: ImageDTO): String
 
     suspend fun getRemoteImage(id: String): ImageDTO
 

--- a/app/src/main/java/com/treasurehunt/data/ImageRepository.kt
+++ b/app/src/main/java/com/treasurehunt/data/ImageRepository.kt
@@ -5,10 +5,9 @@ import com.treasurehunt.data.remote.model.ImageDTO
 
 interface ImageRepository {
 
-    suspend fun insert(imageEntity: ImageEntity): Long
+    suspend fun insert(image: ImageEntity): Long
 
-    suspend fun insert(imageDTO: ImageDTO): String
+    suspend fun insert(image: ImageDTO): String
 
-    suspend fun getRemoteImage(id: String): ImageDTO
-
+    suspend fun getRemoteImageById(id: String): ImageDTO
 }

--- a/app/src/main/java/com/treasurehunt/data/ImageRepositoryImpl.kt
+++ b/app/src/main/java/com/treasurehunt/data/ImageRepositoryImpl.kt
@@ -11,11 +11,9 @@ class ImageRepositoryImpl @Inject constructor(
     private val imageRemoteDataSource: ImageRemoteDataSource
 ) : ImageRepository {
 
-    override suspend fun insertImage(imageEntity: ImageEntity): Long = imageDao.insert(imageEntity)
+    override suspend fun insert(imageEntity: ImageEntity): Long = imageDao.insert(imageEntity)
 
-    override suspend fun insertImage(imageDTO: ImageDTO): String =
-        imageRemoteDataSource.insert(imageDTO)
+    override suspend fun insert(imageDTO: ImageDTO): String = imageRemoteDataSource.insert(imageDTO)
 
-    override suspend fun getRemoteImage(id: String): ImageDTO =
-        imageRemoteDataSource.getImage(id)
+    override suspend fun getRemoteImage(id: String): ImageDTO = imageRemoteDataSource.getRemoteImage(id)
 }

--- a/app/src/main/java/com/treasurehunt/data/ImageRepositoryImpl.kt
+++ b/app/src/main/java/com/treasurehunt/data/ImageRepositoryImpl.kt
@@ -11,9 +11,9 @@ class ImageRepositoryImpl @Inject constructor(
     private val imageRemoteDataSource: ImageRemoteDataSource
 ) : ImageRepository {
 
-    override suspend fun insert(imageEntity: ImageEntity): Long = imageDao.insert(imageEntity)
+    override suspend fun insert(image: ImageEntity) = imageDao.insert(image)
 
-    override suspend fun insert(imageDTO: ImageDTO): String = imageRemoteDataSource.insert(imageDTO)
+    override suspend fun insert(image: ImageDTO) = imageRemoteDataSource.insert(image)
 
-    override suspend fun getRemoteImage(id: String): ImageDTO = imageRemoteDataSource.getRemoteImage(id)
+    override suspend fun getRemoteImageById(id: String) = imageRemoteDataSource.getRemoteImageById(id)
 }

--- a/app/src/main/java/com/treasurehunt/data/LogRepository.kt
+++ b/app/src/main/java/com/treasurehunt/data/LogRepository.kt
@@ -10,17 +10,19 @@ interface LogRepository {
 
     suspend fun insert(log: LogDTO): String
 
-    suspend fun getRemoteLog(id: String): LogDTO
-
-    suspend fun getRemoteAllLogs(): List<LogDTO>
-
     fun getLogById(id: String): Flow<LogEntity>
 
     fun getAllLogs(): Flow<List<LogEntity>>
+
+    suspend fun getRemoteLog(id: String): LogDTO
+
+    suspend fun getAllRemoteLogs(): List<LogDTO>
 
     fun update(log: LogEntity): Int
 
     suspend fun delete(vararg logs: LogEntity): Int
 
     suspend fun deleteAll()
+
+    suspend fun delete(id: String)
 }

--- a/app/src/main/java/com/treasurehunt/data/LogRepository.kt
+++ b/app/src/main/java/com/treasurehunt/data/LogRepository.kt
@@ -10,11 +10,11 @@ interface LogRepository {
 
     suspend fun insert(log: LogDTO): String
 
-    fun getLogById(id: String): Flow<LogEntity>
+    fun getLocalLogById(id: String): Flow<LogEntity>
 
-    fun getAllLogs(): Flow<List<LogEntity>>
+    fun getAllLocalLogs(): Flow<List<LogEntity>>
 
-    suspend fun getRemoteLog(id: String): LogDTO
+    suspend fun getRemoteLogById(id: String): LogDTO
 
     suspend fun getAllRemoteLogs(): List<LogDTO>
 
@@ -22,7 +22,7 @@ interface LogRepository {
 
     suspend fun delete(vararg logs: LogEntity): Int
 
-    suspend fun deleteAll()
+    suspend fun deleteAllLocalLogs()
 
     suspend fun delete(id: String)
 }

--- a/app/src/main/java/com/treasurehunt/data/LogRepositoryImpl.kt
+++ b/app/src/main/java/com/treasurehunt/data/LogRepositoryImpl.kt
@@ -16,13 +16,13 @@ class LogRepositoryImpl @Inject constructor(
 
     override suspend fun insert(logDTD: LogDTO) = logRemoteDataSource.insert(logDTD).name
 
-    override suspend fun getRemoteLog(id: String): LogDTO = logRemoteDataSource.getLog(id)
-
-    override suspend fun getRemoteAllLogs(): List<LogDTO> = logRemoteDataSource.getAllLogs()
-
     override fun getLogById(id: String): Flow<LogEntity> = logDao.getLogById(id)
 
     override fun getAllLogs(): Flow<List<LogEntity>> = logDao.getAllLogs()
+
+    override suspend fun getRemoteLog(id: String): LogDTO = logRemoteDataSource.getRemoteLog(id)
+
+    override suspend fun getAllRemoteLogs(): List<LogDTO> = logRemoteDataSource.getAllRemoteLogs()
 
     override fun update(log: LogEntity) = logDao.update(log)
 
@@ -30,5 +30,9 @@ class LogRepositoryImpl @Inject constructor(
 
     override suspend fun deleteAll() {
         logDao.deleteAllLogs()
+    }
+
+    override suspend fun delete(id: String) {
+        logRemoteDataSource.delete(id)
     }
 }

--- a/app/src/main/java/com/treasurehunt/data/LogRepositoryImpl.kt
+++ b/app/src/main/java/com/treasurehunt/data/LogRepositoryImpl.kt
@@ -4,7 +4,6 @@ import com.treasurehunt.data.local.LogDao
 import com.treasurehunt.data.local.model.LogEntity
 import com.treasurehunt.data.remote.LogRemoteDataSource
 import com.treasurehunt.data.remote.model.LogDTO
-import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
 
 class LogRepositoryImpl @Inject constructor(
@@ -14,22 +13,22 @@ class LogRepositoryImpl @Inject constructor(
 
     override suspend fun insert(log: LogEntity) = logDao.insert(log)
 
-    override suspend fun insert(logDTD: LogDTO) = logRemoteDataSource.insert(logDTD).name
+    override suspend fun insert(log: LogDTO) = logRemoteDataSource.insert(log).name
 
-    override fun getLogById(id: String): Flow<LogEntity> = logDao.getLogById(id)
+    override fun getLocalLogById(id: String) = logDao.getLocalLogById(id)
 
-    override fun getAllLogs(): Flow<List<LogEntity>> = logDao.getAllLogs()
+    override fun getAllLocalLogs() = logDao.getAllLocalLogs()
 
-    override suspend fun getRemoteLog(id: String): LogDTO = logRemoteDataSource.getRemoteLog(id)
+    override suspend fun getRemoteLogById(id: String) = logRemoteDataSource.getRemoteLogById(id)
 
-    override suspend fun getAllRemoteLogs(): List<LogDTO> = logRemoteDataSource.getAllRemoteLogs()
+    override suspend fun getAllRemoteLogs() = logRemoteDataSource.getAllRemoteLogs()
 
     override fun update(log: LogEntity) = logDao.update(log)
 
     override suspend fun delete(vararg logs: LogEntity) = logDao.delete(*logs)
 
-    override suspend fun deleteAll() {
-        logDao.deleteAllLogs()
+    override suspend fun deleteAllLocalLogs() {
+        logDao.deleteAllLocalLogs()
     }
 
     override suspend fun delete(id: String) {

--- a/app/src/main/java/com/treasurehunt/data/PlaceRepository.kt
+++ b/app/src/main/java/com/treasurehunt/data/PlaceRepository.kt
@@ -10,21 +10,21 @@ interface PlaceRepository {
 
     suspend fun insert(place: PlaceDTO): String
 
-    fun getPlaceById(id: String): Flow<PlaceEntity>
+    fun getLocalPlaceById(id: String): Flow<PlaceEntity>
 
-    fun getAllVisits(): Flow<List<PlaceEntity>>
+    fun getAllLocalVisits(): Flow<List<PlaceEntity>>
 
-    fun getAllPlans(): Flow<List<PlaceEntity>>
+    fun getAllLocalPlans(): Flow<List<PlaceEntity>>
 
-    suspend fun getRemotePlace(id: String): PlaceDTO
+    suspend fun getRemotePlaceById(id: String): PlaceDTO
 
     suspend fun update(place: PlaceEntity): Int
 
-    suspend fun update(id: String, placeDTO: PlaceDTO)
+    suspend fun update(id: String, place: PlaceDTO)
 
     suspend fun delete(vararg places: PlaceEntity): Int
 
-    suspend fun deleteAll()
+    suspend fun deleteAllLocalPlaces()
 
     suspend fun delete(id: String)
 }

--- a/app/src/main/java/com/treasurehunt/data/PlaceRepository.kt
+++ b/app/src/main/java/com/treasurehunt/data/PlaceRepository.kt
@@ -10,13 +10,13 @@ interface PlaceRepository {
 
     suspend fun insert(place: PlaceDTO): String
 
-    suspend fun getRemotePlace(id: String): PlaceDTO
-
     fun getPlaceById(id: String): Flow<PlaceEntity>
 
     fun getAllVisits(): Flow<List<PlaceEntity>>
 
     fun getAllPlans(): Flow<List<PlaceEntity>>
+
+    suspend fun getRemotePlace(id: String): PlaceDTO
 
     suspend fun update(place: PlaceEntity): Int
 
@@ -25,4 +25,6 @@ interface PlaceRepository {
     suspend fun delete(vararg places: PlaceEntity): Int
 
     suspend fun deleteAll()
+
+    suspend fun delete(id: String)
 }

--- a/app/src/main/java/com/treasurehunt/data/PlaceRepositoryImpl.kt
+++ b/app/src/main/java/com/treasurehunt/data/PlaceRepositoryImpl.kt
@@ -14,26 +14,26 @@ class PlaceRepositoryImpl @Inject constructor(
 
     override suspend fun insert(place: PlaceEntity) = placeDao.insert(place)
 
-    override suspend fun insert(place: PlaceDTO): String = placeRemoteDataSource.insert(place)
+    override suspend fun insert(place: PlaceDTO) = placeRemoteDataSource.insert(place)
 
-    override fun getPlaceById(id: String): Flow<PlaceEntity> = placeDao.getPlaceById(id)
+    override fun getLocalPlaceById(id: String) = placeDao.getLocalPlaceById(id)
 
-    override fun getAllVisits(): Flow<List<PlaceEntity>> = placeDao.getAllVisits()
+    override fun getAllLocalVisits() = placeDao.getAllLocalVisits()
 
-    override fun getAllPlans(): Flow<List<PlaceEntity>> = placeDao.getAllPlans()
+    override fun getAllLocalPlans() = placeDao.getAllLocalPlans()
 
-    override suspend fun getRemotePlace(id: String): PlaceDTO = placeRemoteDataSource.getRemotePlace(id)
+    override suspend fun getRemotePlaceById(id: String) = placeRemoteDataSource.getRemotePlaceById(id)
 
     override suspend fun update(place: PlaceEntity) = placeDao.update(place)
 
-    override suspend fun update(id: String, placeDTO: PlaceDTO) {
-        placeRemoteDataSource.update(id, placeDTO)
+    override suspend fun update(id: String, place: PlaceDTO) {
+        placeRemoteDataSource.update(id, place)
     }
 
     override suspend fun delete(vararg places: PlaceEntity) = placeDao.delete(*places)
 
-    override suspend fun deleteAll() {
-        placeDao.deleteAll()
+    override suspend fun deleteAllLocalPlaces() {
+        placeDao.deleteAllLocalPlaces()
     }
 
     override suspend fun delete(id: String) {

--- a/app/src/main/java/com/treasurehunt/data/PlaceRepositoryImpl.kt
+++ b/app/src/main/java/com/treasurehunt/data/PlaceRepositoryImpl.kt
@@ -16,13 +16,13 @@ class PlaceRepositoryImpl @Inject constructor(
 
     override suspend fun insert(place: PlaceDTO): String = placeRemoteDataSource.insert(place)
 
-    override suspend fun getRemotePlace(id: String): PlaceDTO = placeRemoteDataSource.getPlace(id)
-
     override fun getPlaceById(id: String): Flow<PlaceEntity> = placeDao.getPlaceById(id)
 
     override fun getAllVisits(): Flow<List<PlaceEntity>> = placeDao.getAllVisits()
 
     override fun getAllPlans(): Flow<List<PlaceEntity>> = placeDao.getAllPlans()
+
+    override suspend fun getRemotePlace(id: String): PlaceDTO = placeRemoteDataSource.getRemotePlace(id)
 
     override suspend fun update(place: PlaceEntity) = placeDao.update(place)
 
@@ -33,6 +33,10 @@ class PlaceRepositoryImpl @Inject constructor(
     override suspend fun delete(vararg places: PlaceEntity) = placeDao.delete(*places)
 
     override suspend fun deleteAll() {
-        placeDao.deleteAllPlaces()
+        placeDao.deleteAll()
+    }
+
+    override suspend fun delete(id: String) {
+        placeRemoteDataSource.delete(id)
     }
 }

--- a/app/src/main/java/com/treasurehunt/data/UserRepository.kt
+++ b/app/src/main/java/com/treasurehunt/data/UserRepository.kt
@@ -7,16 +7,18 @@ import kotlinx.coroutines.flow.Flow
 interface UserRepository {
 
     suspend fun insert(user: UserEntity): Long
+
     suspend fun insert(id: String, data: UserDTO)
-    suspend fun getRemoteUser(id: String): UserDTO
 
-    fun getUserById(id: String): Flow<UserEntity>
+    fun getLocalUserById(id: String): Flow<UserEntity>
 
-    fun getAllUsers(): Flow<List<UserEntity>>
+    fun getAllLocalUsers(): Flow<List<UserEntity>>
+
+    suspend fun getRemoteUserById(id: String): UserDTO
 
     fun update(user: UserEntity): Int
 
-    suspend fun update(id: String, data: UserDTO)
+    suspend fun update(id: String, user: UserDTO)
 
     suspend fun delete(vararg users: UserEntity): Int
 

--- a/app/src/main/java/com/treasurehunt/data/UserRepositoryImpl.kt
+++ b/app/src/main/java/com/treasurehunt/data/UserRepositoryImpl.kt
@@ -4,7 +4,6 @@ import com.treasurehunt.data.local.UserDao
 import com.treasurehunt.data.local.model.UserEntity
 import com.treasurehunt.data.remote.UserRemoteDataSource
 import com.treasurehunt.data.remote.model.UserDTO
-import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
 
 class UserRepositoryImpl @Inject constructor(
@@ -14,20 +13,20 @@ class UserRepositoryImpl @Inject constructor(
 
     override suspend fun insert(user: UserEntity) = userDao.insert(user)
 
-    override suspend fun insert(id: String, data: UserDTO) {
-        userRemoteDataSource.insert(id, data)
+    override suspend fun insert(id: String, user: UserDTO) {
+        userRemoteDataSource.insert(id, user)
     }
 
-    override suspend fun getRemoteUser(id: String): UserDTO = userRemoteDataSource.getUserData(id)
+    override fun getLocalUserById(id: String) = userDao.getLocalUserById(id)
 
-    override fun getUserById(id: String): Flow<UserEntity> = userDao.getUserById(id)
+    override fun getAllLocalUsers() = userDao.getAllLocalUsers()
 
-    override fun getAllUsers(): Flow<List<UserEntity>> = userDao.getAllUsers()
+    override suspend fun getRemoteUserById(id: String) = userRemoteDataSource.getRemoteUserById(id)
 
     override fun update(user: UserEntity) = userDao.update(user)
 
-    override suspend fun update(id: String, data: UserDTO) {
-        userRemoteDataSource.update(id, data)
+    override suspend fun update(id: String, user: UserDTO) {
+        userRemoteDataSource.update(id, user)
     }
 
     override suspend fun delete(vararg users: UserEntity) = userDao.delete(*users)

--- a/app/src/main/java/com/treasurehunt/data/local/Converters.kt
+++ b/app/src/main/java/com/treasurehunt/data/local/Converters.kt
@@ -5,6 +5,7 @@ import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 
 class Converters {
+
     @TypeConverter
     fun fromString(value: String): List<String> = Json.decodeFromString(value)
 

--- a/app/src/main/java/com/treasurehunt/data/local/LogDao.kt
+++ b/app/src/main/java/com/treasurehunt/data/local/LogDao.kt
@@ -15,11 +15,11 @@ interface LogDao {
     @Insert(onConflict = OnConflictStrategy.IGNORE)
     suspend fun insert(log: LogEntity): Long
 
-    @Query("SELECT * from logs WHERE id = :id")
-    fun getLogById(id: String): Flow<LogEntity>
+    @Query("SELECT * from logs WHERE localId = :id")
+    fun getLocalLogById(id: String): Flow<LogEntity>
 
     @Query("SELECT * from logs ORDER BY created_date DESC")
-    fun getAllLogs(): Flow<List<LogEntity>>
+    fun getAllLocalLogs(): Flow<List<LogEntity>>
 
     @Update
     fun update(log: LogEntity): Int
@@ -28,5 +28,5 @@ interface LogDao {
     suspend fun delete(vararg logs: LogEntity): Int
 
     @Query("DELETE FROM logs")
-    suspend fun deleteAllLogs()
+    suspend fun deleteAllLocalLogs()
 }

--- a/app/src/main/java/com/treasurehunt/data/local/PlaceDao.kt
+++ b/app/src/main/java/com/treasurehunt/data/local/PlaceDao.kt
@@ -31,5 +31,5 @@ interface PlaceDao {
     suspend fun delete(vararg places: PlaceEntity): Int
 
     @Query("DELETE FROM places")
-    suspend fun deleteAllPlaces()
+    suspend fun deleteAll()
 }

--- a/app/src/main/java/com/treasurehunt/data/local/PlaceDao.kt
+++ b/app/src/main/java/com/treasurehunt/data/local/PlaceDao.kt
@@ -15,14 +15,14 @@ interface PlaceDao {
     @Insert(onConflict = OnConflictStrategy.IGNORE)
     suspend fun insert(place: PlaceEntity): Long
 
-    @Query("SELECT * from places WHERE id = :id")
-    fun getPlaceById(id: String): Flow<PlaceEntity>
+    @Query("SELECT * from places WHERE localId = :id")
+    fun getLocalPlaceById(id: String): Flow<PlaceEntity>
 
-    @Query("SELECT * from places WHERE `plan` = 0")
-    fun getAllVisits(): Flow<List<PlaceEntity>>
+    @Query("SELECT * from places WHERE isPlan = 0")
+    fun getAllLocalVisits(): Flow<List<PlaceEntity>>
 
-    @Query("SELECT * from places WHERE `plan` = 1")
-    fun getAllPlans(): Flow<List<PlaceEntity>>
+    @Query("SELECT * from places WHERE isPlan = 1")
+    fun getAllLocalPlans(): Flow<List<PlaceEntity>>
 
     @Update
     suspend fun update(place: PlaceEntity): Int
@@ -31,5 +31,5 @@ interface PlaceDao {
     suspend fun delete(vararg places: PlaceEntity): Int
 
     @Query("DELETE FROM places")
-    suspend fun deleteAll()
+    suspend fun deleteAllLocalPlaces()
 }

--- a/app/src/main/java/com/treasurehunt/data/local/UserDao.kt
+++ b/app/src/main/java/com/treasurehunt/data/local/UserDao.kt
@@ -15,11 +15,11 @@ interface UserDao {
     @Insert(onConflict = OnConflictStrategy.IGNORE)
     suspend fun insert(user: UserEntity): Long
 
-    @Query("SELECT * from users WHERE id = :id")
-    fun getUserById(id: String): Flow<UserEntity>
+    @Query("SELECT * from users WHERE localId = :id")
+    fun getLocalUserById(id: String): Flow<UserEntity>
 
     @Query("SELECT * from users")
-    fun getAllUsers(): Flow<List<UserEntity>>
+    fun getAllLocalUsers(): Flow<List<UserEntity>>
 
     @Update
     fun update(user: UserEntity): Int

--- a/app/src/main/java/com/treasurehunt/data/local/model/ImageEntity.kt
+++ b/app/src/main/java/com/treasurehunt/data/local/model/ImageEntity.kt
@@ -10,13 +10,10 @@ data class ImageEntity(
     val url: String,
     @ColumnInfo("local_path")
     val localPath: String? = null,
-    @ColumnInfo("remote_id")
-    val remoteId: String? = null,
     @PrimaryKey(autoGenerate = true)
-    val id: Long = 0
+    val localId: Long = 0,
+    @ColumnInfo("remote_id")
+    val remoteId: String? = null
 )
 
-fun ImageEntity.toImageDTO(): ImageDTO {
-    val (url, _, _, localId) = this
-    return ImageDTO(url, localId)
-}
+fun ImageEntity.toImageDTO() = ImageDTO(url, localId)

--- a/app/src/main/java/com/treasurehunt/data/local/model/LogEntity.kt
+++ b/app/src/main/java/com/treasurehunt/data/local/model/LogEntity.kt
@@ -3,32 +3,25 @@ package com.treasurehunt.data.local.model
 import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.PrimaryKey
-import com.treasurehunt.data.ImageRepository
 import com.treasurehunt.data.remote.model.LogDTO
 import com.treasurehunt.ui.model.LogModel
 
 @Entity(tableName = "logs")
 data class LogEntity(
-    val place: String,
-    val imageIds: List<String>,
+    val remotePlaceId: String,
     val text: String,
     val theme: String,
     @ColumnInfo("created_date")
     val createdDate: Long,
-    @ColumnInfo("remote_id")
-    val remoteId: String? = null,
+    val remoteImageIds: List<String>,
     @PrimaryKey(autoGenerate = true)
-    val id: Long = 0
+    val localId: Long = 0,
+    @ColumnInfo("remote_id")
+    val remoteId: String? = null
 )
 
-fun LogEntity.toLogDTO(): LogDTO {
-    val (place, images, text, theme, createdDate, _, localId) = this
-    return LogDTO(place, images.associateWith { true }, text, theme, createdDate, localId)
-}
+fun LogEntity.toLogDTO() =
+    LogDTO(remotePlaceId, text, theme, createdDate, remoteImageIds.associateWith { true }, localId)
 
-fun LogEntity.toLogModel(
-    imagesUrls: List<String>
-): LogModel {
-    val (place, imageIds, text, theme, createdDate, _, id) = this
-    return LogModel(place, text, theme, createdDate, imageIds, imagesUrls)
-}
+fun LogEntity.toLogModel(imagesUrls: List<String>) =
+    LogModel(remotePlaceId, text, theme, createdDate, remoteImageIds, imagesUrls)

--- a/app/src/main/java/com/treasurehunt/data/local/model/PlaceEntity.kt
+++ b/app/src/main/java/com/treasurehunt/data/local/model/PlaceEntity.kt
@@ -9,16 +9,13 @@ import com.treasurehunt.data.remote.model.PlaceDTO
 data class PlaceEntity(
     val lat: Double,
     val lng: Double,
-    val plan: Boolean,
+    val isPlan: Boolean,
     val caption: String,
-    val log: String? = null,
-    @ColumnInfo("remote_id")
-    val remoteId: String? = null,
+    val remoteLogId: String? = null,
     @PrimaryKey(autoGenerate = true)
-    val id: Long = 0
+    val localId: Long = 0,
+    @ColumnInfo("remote_id")
+    val remoteId: String? = null
 )
 
-fun PlaceEntity.toPlaceDTO(): PlaceDTO {
-    val (lat, lng, plan, caption, log, _, localId) = this
-    return PlaceDTO(lat, lng, plan, caption, log, localId)
-}
+fun PlaceEntity.toPlaceDTO() = PlaceDTO(lat, lng, isPlan, caption, remoteLogId, localId)

--- a/app/src/main/java/com/treasurehunt/data/local/model/UserEntity.kt
+++ b/app/src/main/java/com/treasurehunt/data/local/model/UserEntity.kt
@@ -9,8 +9,8 @@ data class UserEntity(
     val nickname: String,
     @ColumnInfo("profile_image")
     val profileImage: String? = null,
-    @ColumnInfo("remote_id")
-    val remoteId: String? = null,
     @PrimaryKey(autoGenerate = true)
-    val id: Long = 0
+    val localId: Long = 0,
+    @ColumnInfo("remote_id")
+    val remoteId: String? = null
 )

--- a/app/src/main/java/com/treasurehunt/data/remote/ImageRemoteDataSource.kt
+++ b/app/src/main/java/com/treasurehunt/data/remote/ImageRemoteDataSource.kt
@@ -5,7 +5,7 @@ import javax.inject.Inject
 
 class ImageRemoteDataSource @Inject constructor(private val imageService: ImageService) {
 
-    suspend fun insert(imageDTO: ImageDTO) = imageService.insert(imageDTO).name
+    suspend fun insert(image: ImageDTO) = imageService.insert(image).name
 
-    suspend fun getRemoteImage(id: String) = imageService.getRemoteImage(id)
+    suspend fun getRemoteImageById(id: String) = imageService.getRemoteImageById(id)
 }

--- a/app/src/main/java/com/treasurehunt/data/remote/ImageRemoteDataSource.kt
+++ b/app/src/main/java/com/treasurehunt/data/remote/ImageRemoteDataSource.kt
@@ -7,5 +7,5 @@ class ImageRemoteDataSource @Inject constructor(private val imageService: ImageS
 
     suspend fun insert(imageDTO: ImageDTO) = imageService.insert(imageDTO).name
 
-    suspend fun getImage(id: String) = imageService.getImage(id)
+    suspend fun getRemoteImage(id: String) = imageService.getRemoteImage(id)
 }

--- a/app/src/main/java/com/treasurehunt/data/remote/ImageService.kt
+++ b/app/src/main/java/com/treasurehunt/data/remote/ImageService.kt
@@ -10,8 +10,8 @@ import retrofit2.http.Path
 interface ImageService {
 
     @POST("images.json")
-    suspend fun insert(@Body imageDTO: ImageDTO): RemoteIdWrapper
+    suspend fun insert(@Body image: ImageDTO): RemoteIdWrapper
 
     @GET("images/{id}.json")
-    suspend fun getRemoteImage(@Path("id") id: String): ImageDTO
+    suspend fun getRemoteImageById(@Path("id") id: String): ImageDTO
 }

--- a/app/src/main/java/com/treasurehunt/data/remote/ImageService.kt
+++ b/app/src/main/java/com/treasurehunt/data/remote/ImageService.kt
@@ -13,8 +13,5 @@ interface ImageService {
     suspend fun insert(@Body imageDTO: ImageDTO): RemoteIdWrapper
 
     @GET("images/{id}.json")
-    suspend fun getImage(
-        @Path("id") id: String
-    ): ImageDTO
-
+    suspend fun getRemoteImage(@Path("id") id: String): ImageDTO
 }

--- a/app/src/main/java/com/treasurehunt/data/remote/LogRemoteDataSource.kt
+++ b/app/src/main/java/com/treasurehunt/data/remote/LogRemoteDataSource.kt
@@ -5,11 +5,11 @@ import javax.inject.Inject
 
 class LogRemoteDataSource @Inject constructor(private val logService: LogService) {
 
-    suspend fun insert(logDTO: LogDTO) = logService.insert(logDTO)
+    suspend fun insert(log: LogDTO) = logService.insert(log)
 
-    suspend fun getRemoteLog(id: String) = logService.getRemoteLog(id)
+    suspend fun getRemoteLogById(id: String) = logService.getRemoteLogById(id)
 
-    suspend fun getAllRemoteLogs(): List<LogDTO> = logService.getAllRemoteLogs()
+    suspend fun getAllRemoteLogs() = logService.getAllRemoteLogs()
 
     suspend fun delete(id: String) {
         logService.delete(id)

--- a/app/src/main/java/com/treasurehunt/data/remote/LogRemoteDataSource.kt
+++ b/app/src/main/java/com/treasurehunt/data/remote/LogRemoteDataSource.kt
@@ -5,9 +5,13 @@ import javax.inject.Inject
 
 class LogRemoteDataSource @Inject constructor(private val logService: LogService) {
 
-    suspend fun getLog(id: String) = logService.getLog(id)
-
-    suspend fun getAllLogs(): List<LogDTO> = logService.getAllLogs()
-
     suspend fun insert(logDTO: LogDTO) = logService.insert(logDTO)
+
+    suspend fun getRemoteLog(id: String) = logService.getRemoteLog(id)
+
+    suspend fun getAllRemoteLogs(): List<LogDTO> = logService.getAllRemoteLogs()
+
+    suspend fun delete(id: String) {
+        logService.delete(id)
+    }
 }

--- a/app/src/main/java/com/treasurehunt/data/remote/LogService.kt
+++ b/app/src/main/java/com/treasurehunt/data/remote/LogService.kt
@@ -13,12 +13,12 @@ interface LogService {
     @POST("logs.json")
     suspend fun insert(@Body logDTO: LogDTO): RemoteIdWrapper
 
-    @GET("/logs/{id}.json")
+    @GET("logs/{id}.json")
     suspend fun getRemoteLog(@Path("id") id: String): LogDTO
 
     @GET("logs.json")
     suspend fun getAllRemoteLogs(): List<LogDTO>
 
-    @DELETE("/logs/{id}.json")
+    @DELETE("logs/{id}.json")
     suspend fun delete(@Path("id") id: String)
 }

--- a/app/src/main/java/com/treasurehunt/data/remote/LogService.kt
+++ b/app/src/main/java/com/treasurehunt/data/remote/LogService.kt
@@ -14,7 +14,7 @@ interface LogService {
     suspend fun insert(@Body logDTO: LogDTO): RemoteIdWrapper
 
     @GET("logs/{id}.json")
-    suspend fun getRemoteLog(@Path("id") id: String): LogDTO
+    suspend fun getRemoteLogById(@Path("id") id: String): LogDTO
 
     @GET("logs.json")
     suspend fun getAllRemoteLogs(): List<LogDTO>

--- a/app/src/main/java/com/treasurehunt/data/remote/LogService.kt
+++ b/app/src/main/java/com/treasurehunt/data/remote/LogService.kt
@@ -3,20 +3,22 @@ package com.treasurehunt.data.remote
 import com.treasurehunt.data.remote.model.LogDTO
 import com.treasurehunt.data.remote.model.RemoteIdWrapper
 import retrofit2.http.Body
+import retrofit2.http.DELETE
 import retrofit2.http.GET
 import retrofit2.http.POST
 import retrofit2.http.Path
 
 interface LogService {
 
-    @GET("/logs/{id}.json")
-    suspend fun getLog(
-        @Path("id") id: String
-    ): LogDTO
-
-    @GET("logs.json")
-    suspend fun getAllLogs(): List<LogDTO>
-
     @POST("logs.json")
     suspend fun insert(@Body logDTO: LogDTO): RemoteIdWrapper
+
+    @GET("/logs/{id}.json")
+    suspend fun getRemoteLog(@Path("id") id: String): LogDTO
+
+    @GET("logs.json")
+    suspend fun getAllRemoteLogs(): List<LogDTO>
+
+    @DELETE("/logs/{id}.json")
+    suspend fun delete(@Path("id") id: String)
 }

--- a/app/src/main/java/com/treasurehunt/data/remote/PlaceRemoteDataSource.kt
+++ b/app/src/main/java/com/treasurehunt/data/remote/PlaceRemoteDataSource.kt
@@ -7,9 +7,13 @@ class PlaceRemoteDataSource @Inject constructor(private val placeService: PlaceS
 
     suspend fun insert(placeDTO: PlaceDTO) = placeService.insert(placeDTO).name
 
-    suspend fun getPlace(id: String) = placeService.getPlace(id)
+    suspend fun getRemotePlace(id: String) = placeService.getRemotePlace(id)
 
     suspend fun update(id: String, placeDTO: PlaceDTO) {
         placeService.update(id, placeDTO)
+    }
+
+    suspend fun delete(id: String) {
+        placeService.delete(id)
     }
 }

--- a/app/src/main/java/com/treasurehunt/data/remote/PlaceRemoteDataSource.kt
+++ b/app/src/main/java/com/treasurehunt/data/remote/PlaceRemoteDataSource.kt
@@ -5,12 +5,12 @@ import javax.inject.Inject
 
 class PlaceRemoteDataSource @Inject constructor(private val placeService: PlaceService) {
 
-    suspend fun insert(placeDTO: PlaceDTO) = placeService.insert(placeDTO).name
+    suspend fun insert(place: PlaceDTO) = placeService.insert(place).name
 
-    suspend fun getRemotePlace(id: String) = placeService.getRemotePlace(id)
+    suspend fun getRemotePlaceById(id: String) = placeService.getRemotePlaceById(id)
 
-    suspend fun update(id: String, placeDTO: PlaceDTO) {
-        placeService.update(id, placeDTO)
+    suspend fun update(id: String, place: PlaceDTO) {
+        placeService.update(id, place)
     }
 
     suspend fun delete(id: String) {

--- a/app/src/main/java/com/treasurehunt/data/remote/PlaceService.kt
+++ b/app/src/main/java/com/treasurehunt/data/remote/PlaceService.kt
@@ -3,6 +3,7 @@ package com.treasurehunt.data.remote
 import com.treasurehunt.data.remote.model.PlaceDTO
 import com.treasurehunt.data.remote.model.RemoteIdWrapper
 import retrofit2.http.Body
+import retrofit2.http.DELETE
 import retrofit2.http.GET
 import retrofit2.http.PATCH
 import retrofit2.http.POST
@@ -14,13 +15,14 @@ interface PlaceService {
     suspend fun insert(@Body placeDTO: PlaceDTO): RemoteIdWrapper
 
     @GET("/places/{id}.json")
-    suspend fun getPlace(
-        @Path("id") id: String
-    ): PlaceDTO
+    suspend fun getRemotePlace(@Path("id") id: String): PlaceDTO
 
     @PATCH("/places/{id}.json")
     suspend fun update(
         @Path("id") id: String,
         @Body data: PlaceDTO
     )
+
+    @DELETE("/places/{id}.json")
+    suspend fun delete(@Path("id") id: String)
 }

--- a/app/src/main/java/com/treasurehunt/data/remote/PlaceService.kt
+++ b/app/src/main/java/com/treasurehunt/data/remote/PlaceService.kt
@@ -14,15 +14,15 @@ interface PlaceService {
     @POST("places.json")
     suspend fun insert(@Body placeDTO: PlaceDTO): RemoteIdWrapper
 
-    @GET("/places/{id}.json")
+    @GET("places/{id}.json")
     suspend fun getRemotePlace(@Path("id") id: String): PlaceDTO
 
-    @PATCH("/places/{id}.json")
+    @PATCH("places/{id}.json")
     suspend fun update(
         @Path("id") id: String,
         @Body data: PlaceDTO
     )
 
-    @DELETE("/places/{id}.json")
+    @DELETE("places/{id}.json")
     suspend fun delete(@Path("id") id: String)
 }

--- a/app/src/main/java/com/treasurehunt/data/remote/PlaceService.kt
+++ b/app/src/main/java/com/treasurehunt/data/remote/PlaceService.kt
@@ -12,15 +12,15 @@ import retrofit2.http.Path
 interface PlaceService {
 
     @POST("places.json")
-    suspend fun insert(@Body placeDTO: PlaceDTO): RemoteIdWrapper
+    suspend fun insert(@Body place: PlaceDTO): RemoteIdWrapper
 
     @GET("places/{id}.json")
-    suspend fun getRemotePlace(@Path("id") id: String): PlaceDTO
+    suspend fun getRemotePlaceById(@Path("id") id: String): PlaceDTO
 
     @PATCH("places/{id}.json")
     suspend fun update(
         @Path("id") id: String,
-        @Body data: PlaceDTO
+        @Body place: PlaceDTO
     )
 
     @DELETE("places/{id}.json")

--- a/app/src/main/java/com/treasurehunt/data/remote/UserRemoteDataSource.kt
+++ b/app/src/main/java/com/treasurehunt/data/remote/UserRemoteDataSource.kt
@@ -1,21 +1,20 @@
 package com.treasurehunt.data.remote
 
-import android.util.Log
 import com.treasurehunt.data.remote.model.UserDTO
 import com.treasurehunt.util.convertToDataClass
 import javax.inject.Inject
 
 class UserRemoteDataSource @Inject constructor(private val userService: UserService) {
 
-    suspend fun insert(uid: String, userDTO: UserDTO) {
-        userService.insert(uid, userDTO)
+    suspend fun insert(id: String, user: UserDTO) {
+        userService.insert(id, user)
     }
 
-    suspend fun update(uid: String, userDTO: UserDTO) {
-        userService.update(uid, userDTO)
+    suspend fun update(id: String, user: UserDTO) {
+        userService.update(id, user)
     }
 
-    suspend fun getUserData(id: String) = userService.getUser(id)
+    suspend fun getRemoteUserById(id: String) = userService.getRemoteUserById(id)
 
     suspend fun search(startAt: String, limit: Int = 10): Map<String, UserDTO> {
         return try {

--- a/app/src/main/java/com/treasurehunt/data/remote/UserService.kt
+++ b/app/src/main/java/com/treasurehunt/data/remote/UserService.kt
@@ -11,24 +11,24 @@ import retrofit2.http.Query
 
 interface UserService {
 
-    @PUT("/users/{id}.json")
+    @PUT("users/{id}.json")
     suspend fun insert(
         @Path("id") id: String,
         @Body userDTO: UserDTO
     )
 
-    @GET("/users/{id}.json")
+    @GET("users/{id}.json")
     suspend fun getUser(
         @Path("id") id: String
     ): UserDTO
 
-    @PATCH("/users/{id}.json")
+    @PATCH("users/{id}.json")
     suspend fun update(
         @Path("id") id: String,
         @Body userDTO: UserDTO
     )
 
-    @GET("/users.json")
+    @GET("users.json")
     suspend fun search(
         @Query("orderBy") orderBy: String,
         @Query("startAt") startAt: String,

--- a/app/src/main/java/com/treasurehunt/data/remote/UserService.kt
+++ b/app/src/main/java/com/treasurehunt/data/remote/UserService.kt
@@ -14,18 +14,16 @@ interface UserService {
     @PUT("users/{id}.json")
     suspend fun insert(
         @Path("id") id: String,
-        @Body userDTO: UserDTO
+        @Body user: UserDTO
     )
 
     @GET("users/{id}.json")
-    suspend fun getUser(
-        @Path("id") id: String
-    ): UserDTO
+    suspend fun getRemoteUserById(@Path("id") id: String): UserDTO
 
     @PATCH("users/{id}.json")
     suspend fun update(
         @Path("id") id: String,
-        @Body userDTO: UserDTO
+        @Body user: UserDTO
     )
 
     @GET("users.json")

--- a/app/src/main/java/com/treasurehunt/data/remote/model/ImageDTO.kt
+++ b/app/src/main/java/com/treasurehunt/data/remote/model/ImageDTO.kt
@@ -10,12 +10,8 @@ data class ImageDTO(
     val localId: Long = 0
 )
 
-fun ImageDTO.toImageEntity(remoteId: String): ImageEntity {
-    val (url, localId) = this
-    return ImageEntity(url, null, remoteId, localId)
-}
+fun ImageDTO.toImageEntity(remoteId: String): ImageEntity =
+    ImageEntity(url, null, localId, remoteId)
 
-fun ImageDTO.toImageModel(): ImageModel {
-    val (url, localId) = this
-    return ImageModel(url)
-}
+fun ImageDTO.toImageModel(): ImageModel =
+    ImageModel(url)

--- a/app/src/main/java/com/treasurehunt/data/remote/model/LogDTO.kt
+++ b/app/src/main/java/com/treasurehunt/data/remote/model/LogDTO.kt
@@ -5,15 +5,20 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class LogDTO(
-    val place: String,
-    val images: Map<String, Boolean>,
+    val remotePlaceId: String,
     val text: String,
     val theme: String,
     val createdDate: Long,
+    val remoteImageIds: Map<String, Boolean>,
     val localId: Long = 0
 )
 
-fun LogDTO.toLogEntity(remoteId: String): LogEntity {
-    val (place, images, text, theme, createdDate, localId) = this
-    return LogEntity(place, images.keys.toList(), text, theme, createdDate, remoteId, localId)
-}
+fun LogDTO.toLogEntity(remoteId: String) = LogEntity(
+    remotePlaceId,
+    text,
+    theme,
+    createdDate,
+    remoteImageIds.keys.toList(),
+    localId,
+    remoteId
+)

--- a/app/src/main/java/com/treasurehunt/data/remote/model/PlaceDTO.kt
+++ b/app/src/main/java/com/treasurehunt/data/remote/model/PlaceDTO.kt
@@ -7,13 +7,18 @@ import kotlinx.serialization.Serializable
 data class PlaceDTO(
     val lat: Double,
     val lng: Double,
-    val plan: Boolean,
+    val isPlan: Boolean,
     val caption: String,
-    val log: String? = null,
+    val remoteLogId: String? = null,
     val localId: Long = 0
 )
 
-fun PlaceDTO.toPlaceEntity(remoteId: String): PlaceEntity {
-    val (lat, lng, plan, caption, log, localId) = this
-    return PlaceEntity(lat, lng, plan, caption, log, remoteId, localId)
-}
+fun PlaceDTO.toPlaceEntity(remoteId: String) = PlaceEntity(
+    lat,
+    lng,
+    isPlan,
+    caption,
+    remoteLogId,
+    localId,
+    remoteId
+)

--- a/app/src/main/java/com/treasurehunt/data/remote/model/UserDTO.kt
+++ b/app/src/main/java/com/treasurehunt/data/remote/model/UserDTO.kt
@@ -8,15 +8,23 @@ data class UserDTO(
     val email: String?,
     val nickname: String? = null,
     val profileImage: String? = null,
-    val public: Boolean = false,
-    val friends: Map<String, Boolean> = emptyMap(),
-    val logs: Map<String, Boolean> = emptyMap(),
-    val places: Map<String, Boolean> = emptyMap(),
-    val plans: Map<String, Boolean> = emptyMap(),
+    val isPublic: Boolean = false,
+    val remoteFriendIds: Map<String, Boolean> = emptyMap(),
+    val remoteLogIds: Map<String, Boolean> = emptyMap(),
+    val remoteVisitIds: Map<String, Boolean> = emptyMap(),
+    val remotePlanIds: Map<String, Boolean> = emptyMap(),
     val localId: Long = 0,
     val remoteId: String? = null
 )
 
-fun UserDTO.toUserModel(remoteId: String? = null): UserModel {
-    return UserModel(email, nickname, profileImage, friends, logs, places, plans, remoteId)
-}
+fun UserDTO.toUserModel(remoteId: String? = null) =
+    UserModel(
+        email,
+        nickname,
+        profileImage,
+        remoteFriendIds,
+        remoteLogIds,
+        remoteVisitIds,
+        remotePlanIds,
+        remoteId
+    )

--- a/app/src/main/java/com/treasurehunt/ui/feed/FeedViewModel.kt
+++ b/app/src/main/java/com/treasurehunt/ui/feed/FeedViewModel.kt
@@ -30,7 +30,7 @@ class FeedViewModel @Inject constructor(
 
     private fun getAllLogs() {
         viewModelScope.launch {
-            logRepo.getAllLogs().collect { allLogs ->
+            logRepo.getAllLocalLogs().collect { allLogs ->
                 _uiState.update {
                     FeedUiState(convertLogModels(allLogs), true)
                 }
@@ -40,13 +40,13 @@ class FeedViewModel @Inject constructor(
 
     private suspend fun convertLogModels(logEntities: List<LogEntity>): List<LogModel> {
         return logEntities.map { logEntity ->
-            logEntity.toLogModel(getImageUrls(logEntity.imageIds))
+            logEntity.toLogModel(getImageUrls(logEntity.remoteImageIds))
         }
     }
 
     private suspend fun getImageUrls(imageIds: List<String>): List<String> {
         return imageIds.map { id ->
-            imageRepo.getRemoteImage(id).url
+            imageRepo.getRemoteImageById(id).url
         }
     }
 

--- a/app/src/main/java/com/treasurehunt/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/treasurehunt/ui/home/HomeFragment.kt
@@ -129,15 +129,11 @@ class HomeFragment : Fragment(), OnMapReadyCallback {
             val mapSymbol = MapSymbol(
                 symbol.position.latitude,
                 symbol.position.longitude,
-                caption = symbol.caption
+                false,
+                symbol.caption
             )
-            val action =
-                HomeFragmentDirections.actionHomeFragmentToMapDialogFragment(
-                    mapSymbol
-                )
-
+            val action = HomeFragmentDirections.actionHomeFragmentToMapDialogFragment(mapSymbol)
             findNavController().navigate(action)
-
             true
         }
     }
@@ -194,12 +190,9 @@ class HomeFragment : Fragment(), OnMapReadyCallback {
                     plan.caption,
                     remotePlaceId
                 )
-                val action = HomeFragmentDirections.actionHomeFragmentToSaveLogFragment(
-                    mapSymbol
-                )
+                val action = HomeFragmentDirections.actionHomeFragmentToSaveLogFragment(mapSymbol)
                 findNavController().navigate(action)
             }
-
             true
         }
     }

--- a/app/src/main/java/com/treasurehunt/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/treasurehunt/ui/home/HomeFragment.kt
@@ -129,7 +129,7 @@ class HomeFragment : Fragment(), OnMapReadyCallback {
             val mapSymbol = MapSymbol(
                 symbol.position.latitude,
                 symbol.position.longitude,
-                symbol.caption
+                caption = symbol.caption
             )
             val action =
                 HomeFragmentDirections.actionHomeFragmentToMapDialogFragment(
@@ -190,8 +190,8 @@ class HomeFragment : Fragment(), OnMapReadyCallback {
                 val mapSymbol = MapSymbol(
                     plan.lat,
                     plan.lng,
-                    plan.caption,
                     true,
+                    plan.caption,
                     remotePlaceId
                 )
                 val action = HomeFragmentDirections.actionHomeFragmentToSaveLogFragment(

--- a/app/src/main/java/com/treasurehunt/ui/home/MapDialogFragment.kt
+++ b/app/src/main/java/com/treasurehunt/ui/home/MapDialogFragment.kt
@@ -50,10 +50,9 @@ class MapDialogFragment : BottomSheetDialogFragment() {
                 findNavController().navigateUp()
             }
 
-            val action =
-                MapDialogFragmentDirections.actionMapDialogFragmentToSaveLogFragment(
-                    args.mapSymbol
-                )
+            val action = MapDialogFragmentDirections.actionMapDialogFragmentToSaveLogFragment(
+                args.mapSymbol
+            )
             findNavController().navigate(action)
         }
     }
@@ -65,7 +64,7 @@ class MapDialogFragment : BottomSheetDialogFragment() {
             }
 
             val uid = viewModel.uiState.value.uid ?: return@setOnClickListener
-            val (lat, lng, isPlan, caption) = args.mapSymbol
+            val (lat, lng, _, caption) = args.mapSymbol
             val planEntity = PlaceEntity(
                 lat,
                 lng,
@@ -90,7 +89,10 @@ class MapDialogFragment : BottomSheetDialogFragment() {
                     remotePlanId,
                     planDTO.copy(localId = localPlanId)
                 )
-                viewModel.updateUser(uid, user.copy(remotePlanIds = user.remotePlanIds + (remotePlanId to true)))
+                viewModel.updateUser(
+                    uid,
+                    user.copy(remotePlanIds = user.remotePlanIds + (remotePlanId to true))
+                )
 
                 findNavController().navigateUp()
             }

--- a/app/src/main/java/com/treasurehunt/ui/home/MapDialogFragment.kt
+++ b/app/src/main/java/com/treasurehunt/ui/home/MapDialogFragment.kt
@@ -65,7 +65,7 @@ class MapDialogFragment : BottomSheetDialogFragment() {
             }
 
             val uid = viewModel.uiState.value.uid ?: return@setOnClickListener
-            val (lat, lng, caption) = args.mapSymbol
+            val (lat, lng, isPlan, caption) = args.mapSymbol
             val planEntity = PlaceEntity(
                 lat,
                 lng,
@@ -84,13 +84,13 @@ class MapDialogFragment : BottomSheetDialogFragment() {
                 val localPlanId = viewModel.addPlace(planEntity)
                 val remotePlanId = viewModel.addPlace(planDTO.copy(localId = localPlanId))
                 viewModel.updatePlace(
-                    planEntity.copy(id = localPlanId, remoteId = remotePlanId)
+                    planEntity.copy(localId = localPlanId, remoteId = remotePlanId)
                 )
                 viewModel.updatePlace(
                     remotePlanId,
                     planDTO.copy(localId = localPlanId)
                 )
-                viewModel.updateUser(uid, user.copy(plans = user.plans + (remotePlanId to true)))
+                viewModel.updateUser(uid, user.copy(remotePlanIds = user.remotePlanIds + (remotePlanId to true)))
 
                 findNavController().navigateUp()
             }

--- a/app/src/main/java/com/treasurehunt/ui/login/LoginViewModel.kt
+++ b/app/src/main/java/com/treasurehunt/ui/login/LoginViewModel.kt
@@ -55,23 +55,23 @@ class LoginViewModel @Inject constructor(
 
     suspend fun initLocalData() {
         val curUserUid = Firebase.auth.currentUser!!.uid
-        val userDTO = userRepo.getRemoteUser(curUserUid)
+        val userDTO = userRepo.getRemoteUserById(curUserUid)
         initLocalLogs(userDTO)
         initLocalPlaces(userDTO)
     }
 
     private suspend fun initLocalLogs(userDTO: UserDTO) {
-        logRepo.deleteAll()
-        userDTO.logs.map {
-            val log = logRepo.getRemoteLog(it.key)
+        logRepo.deleteAllLocalLogs()
+        userDTO.remoteLogIds.map {
+            val log = logRepo.getRemoteLogById(it.key)
             logRepo.insert(log.toLogEntity(it.key))
         }
     }
 
     private suspend fun initLocalPlaces(userDTO: UserDTO) {
-        placeRepo.deleteAll()
-        userDTO.places.map {
-            val place = placeRepo.getRemotePlace(it.key)
+        placeRepo.deleteAllLocalPlaces()
+        userDTO.remoteVisitIds.map {
+            val place = placeRepo.getRemotePlaceById(it.key)
             placeRepo.insert(place.toPlaceEntity(it.key))
         }
     }

--- a/app/src/main/java/com/treasurehunt/ui/model/ImageModel.kt
+++ b/app/src/main/java/com/treasurehunt/ui/model/ImageModel.kt
@@ -1,5 +1,5 @@
 package com.treasurehunt.ui.model
 
 data class ImageModel(
-    val uri: String,
+    val uri: String
 )

--- a/app/src/main/java/com/treasurehunt/ui/model/LogModel.kt
+++ b/app/src/main/java/com/treasurehunt/ui/model/LogModel.kt
@@ -7,20 +7,16 @@ import kotlinx.android.parcel.Parcelize
 
 @Parcelize
 data class LogModel(
-    val place: String,
+    val remotePlaceId: String,
     val text: String,
     val theme: String,
     val createdDate: Long,
-    val imageIds: List<String>,
-    val imageUrls: List<String> = emptyList(),
+    val remoteImageIds: List<String>,
+    val imageUrls: List<String> = emptyList()
 ) : Parcelable
 
-fun LogModel.asLogEntity(remoteId: String? = null, localId: Long = 0): LogEntity {
-    val (place, text, theme, createdDate, imageIds) = this
-    return LogEntity(place, text, theme, createdDate, imageIds, localId, remoteId)
-}
+fun LogModel.asLogEntity(localId: Long = 0, remoteId: String? = null) =
+    LogEntity(remotePlaceId, text, theme, createdDate, remoteImageIds, localId, remoteId)
 
-fun LogModel.asLogDTO(localId: Long = 0): LogDTO {
-    val (place, text, theme, createdDate,imageIds) = this
-    return LogDTO(place, text, theme, createdDate, imageIds.associateWith { true }, localId)
-}
+fun LogModel.asLogDTO(localId: Long = 0) =
+    LogDTO(remotePlaceId, text, theme, createdDate, remoteImageIds.associateWith { true }, localId)

--- a/app/src/main/java/com/treasurehunt/ui/model/LogModel.kt
+++ b/app/src/main/java/com/treasurehunt/ui/model/LogModel.kt
@@ -17,10 +17,10 @@ data class LogModel(
 
 fun LogModel.asLogEntity(remoteId: String? = null, localId: Long = 0): LogEntity {
     val (place, text, theme, createdDate, imageIds) = this
-    return LogEntity(place, imageIds, text, theme, createdDate, remoteId, localId)
+    return LogEntity(place, text, theme, createdDate, imageIds, localId, remoteId)
 }
 
 fun LogModel.asLogDTO(localId: Long = 0): LogDTO {
     val (place, text, theme, createdDate,imageIds) = this
-    return LogDTO(place, imageIds.associateWith { true }, text, theme, createdDate, localId)
+    return LogDTO(place, text, theme, createdDate, imageIds.associateWith { true }, localId)
 }

--- a/app/src/main/java/com/treasurehunt/ui/model/MapSymbol.kt
+++ b/app/src/main/java/com/treasurehunt/ui/model/MapSymbol.kt
@@ -7,13 +7,13 @@ import kotlinx.parcelize.Parcelize
 data class MapSymbol(
     val lat: Double,
     val lng: Double,
-    val caption: String,
     val isPlan: Boolean = false,
-    val remoteId: String? = null
+    val caption: String,
+    val remotePlanId: String? = null
 ) : Parcelable
 
 fun MapSymbol.toPlace(): PlaceModel {
-    val (lat, lng, caption) = this
+    val (lat, lng, isPlan, caption) = this
     return PlaceModel(
         lat,
         lng,

--- a/app/src/main/java/com/treasurehunt/ui/model/MapSymbol.kt
+++ b/app/src/main/java/com/treasurehunt/ui/model/MapSymbol.kt
@@ -7,17 +7,10 @@ import kotlinx.parcelize.Parcelize
 data class MapSymbol(
     val lat: Double,
     val lng: Double,
-    val isPlan: Boolean = false,
+    val isPlan: Boolean,
     val caption: String,
     val remotePlanId: String? = null
 ) : Parcelable
 
-fun MapSymbol.toPlace(): PlaceModel {
-    val (lat, lng, isPlan, caption) = this
-    return PlaceModel(
-        lat,
-        lng,
-        false,
-        caption
-    )
-}
+fun MapSymbol.toPlace() = PlaceModel(lat, lng, isPlan, caption)
+

--- a/app/src/main/java/com/treasurehunt/ui/model/PlaceModel.kt
+++ b/app/src/main/java/com/treasurehunt/ui/model/PlaceModel.kt
@@ -6,14 +6,14 @@ import com.treasurehunt.data.remote.model.PlaceDTO
 data class PlaceModel(
     val lat: Double,
     val lng: Double,
-    val plan: Boolean,
+    val isPlan: Boolean,
     val caption: String,
-    val log: String? = null
+    val remoteLogId: String? = null
 )
 
 fun PlaceModel.asPlaceEntity(remoteId: String? = null, localId: Long = 0): PlaceEntity {
     val (lat, lng, plan, caption, log) = this
-    return PlaceEntity(lat, lng, plan, caption, log, remoteId, localId)
+    return PlaceEntity(lat, lng, plan, caption, log, localId, remoteId)
 }
 
 fun PlaceModel.asPlaceDTO(localId: Long = 0): PlaceDTO {

--- a/app/src/main/java/com/treasurehunt/ui/model/PlaceModel.kt
+++ b/app/src/main/java/com/treasurehunt/ui/model/PlaceModel.kt
@@ -11,12 +11,8 @@ data class PlaceModel(
     val remoteLogId: String? = null
 )
 
-fun PlaceModel.asPlaceEntity(remoteId: String? = null, localId: Long = 0): PlaceEntity {
-    val (lat, lng, plan, caption, log) = this
-    return PlaceEntity(lat, lng, plan, caption, log, localId, remoteId)
-}
+fun PlaceModel.asPlaceEntity(localId: Long = 0, remoteId: String? = null) =
+    PlaceEntity(lat, lng, isPlan, caption, remoteLogId, localId, remoteId)
 
-fun PlaceModel.asPlaceDTO(localId: Long = 0): PlaceDTO {
-    val (lat, lng, plan, caption, log) = this
-    return PlaceDTO(lat, lng, plan, caption, log, localId)
-}
+fun PlaceModel.asPlaceDTO(localId: Long = 0) =
+    PlaceDTO(lat, lng, isPlan, caption, remoteLogId, localId)

--- a/app/src/main/java/com/treasurehunt/ui/model/UserModel.kt
+++ b/app/src/main/java/com/treasurehunt/ui/model/UserModel.kt
@@ -4,9 +4,9 @@ data class UserModel(
     val email: String?,
     val nickName: String? = null,
     val profileImage: String? = null,
-    val friends: Map<String, Boolean> = emptyMap(),
-    val logs: Map<String, Boolean> = emptyMap(),
-    val places: Map<String, Boolean> = emptyMap(),
-    val plans: Map<String, Boolean> = emptyMap(),
+    val remoteFriendIds: Map<String, Boolean> = emptyMap(),
+    val remoteLogIds: Map<String, Boolean> = emptyMap(),
+    val remoteVisitIds: Map<String, Boolean> = emptyMap(),
+    val remotePlanIds: Map<String, Boolean> = emptyMap(),
     val remoteId: String? = null
 )

--- a/app/src/main/java/com/treasurehunt/ui/profile/FriendViewModel.kt
+++ b/app/src/main/java/com/treasurehunt/ui/profile/FriendViewModel.kt
@@ -97,7 +97,7 @@ class FriendViewModel @Inject constructor(
         friendIds.stateIn(viewModelScope, SharingStarted.WhileSubscribed(), emptyList())
             .collect { friendIds ->
                 val friends = friendIds.map { friendId ->
-                    userRepo.getRemoteUser(friendId).toUserModel(remoteId = friendId)
+                    userRepo.getRemoteUserById(friendId).toUserModel(remoteId = friendId)
                 }
                 _uiState.update {
                     it.copy(friends = friends.associateWith { true })
@@ -117,29 +117,29 @@ class FriendViewModel @Inject constructor(
     }
 
     suspend fun addFriend(uid: String, friendId: String) {
-        val user = userRepo.getRemoteUser(uid)
-        if (user.friends[friendId] == true) return
+        val user = userRepo.getRemoteUserById(uid)
+        if (user.remoteFriendIds[friendId] == true) return
 
         userRepo.update(
-            uid, user.copy(friends = user.friends + (friendId to true))
+            uid, user.copy(remoteFriendIds = user.remoteFriendIds + (friendId to true))
         )
 
         _uiState.update { uiState ->
-            val friend = userRepo.getRemoteUser(friendId).toUserModel(friendId)
+            val friend = userRepo.getRemoteUserById(friendId).toUserModel(friendId)
             uiState.copy(friends = uiState.friends + (friend to true))
         }
     }
 
     suspend fun removeFriend(uid: String, friendId: String) {
-        val user = userRepo.getRemoteUser(uid)
-        if (user.friends[friendId] != true) return
+        val user = userRepo.getRemoteUserById(uid)
+        if (user.remoteFriendIds[friendId] != true) return
 
         userRepo.update(
-            uid, user.copy(friends = user.friends + (friendId to false))
+            uid, user.copy(remoteFriendIds = user.remoteFriendIds + (friendId to false))
         )
 
         _uiState.update {
-            val friend = userRepo.getRemoteUser(friendId).toUserModel(friendId)
+            val friend = userRepo.getRemoteUserById(friendId).toUserModel(friendId)
             it.copy(friends = it.friends - friend)
         }
     }

--- a/app/src/main/java/com/treasurehunt/ui/profile/ProfileViewModel.kt
+++ b/app/src/main/java/com/treasurehunt/ui/profile/ProfileViewModel.kt
@@ -41,7 +41,7 @@ class ProfileViewModel @Inject constructor(
     fun getUserData() {
         val uid = Firebase.auth.currentUser!!.uid
         viewModelScope.launch {
-            _userData.value = userRepository.getRemoteUser(uid)
+            _userData.value = userRepository.getRemoteUserById(uid)
         }
     }
 

--- a/app/src/main/java/com/treasurehunt/ui/savelog/DatabaseUpdateWorker.kt
+++ b/app/src/main/java/com/treasurehunt/ui/savelog/DatabaseUpdateWorker.kt
@@ -84,7 +84,7 @@ class DatabaseUpdateWorker @AssistedInject constructor(
         val localPlaceId = placeRepo.insert(place.asPlaceEntity())
 
         placeRepo.update(
-            place.asPlaceEntity(remotePlaceId, localPlaceId)
+            place.asPlaceEntity(localPlaceId, remotePlaceId)
         )
 
         placeRepo.update(

--- a/app/src/main/java/com/treasurehunt/ui/savelog/SaveLogFragment.kt
+++ b/app/src/main/java/com/treasurehunt/ui/savelog/SaveLogFragment.kt
@@ -246,7 +246,7 @@ class SaveLogFragment : Fragment(), OnMapReadyCallback {
 
     private fun getDatabaseUpdateRequest(): OneTimeWorkRequest {
         val uid = Firebase.auth.currentUser!!.uid
-        val (lat, lng, caption, isPlan, planId) = args.mapSymbol
+        val (lat, lng, isPlan, caption, planId) = args.mapSymbol
         val logText = binding.etText.text.toString()
         val data = Data.Builder()
             .putString(WORK_DATA_UID, uid)


### PR DESCRIPTION
DB 관련 함수들 이름과 순서 통일했습니다
이름의 경우, insert, get, update, delete 등으로 원래 심플하게 돼있던 거 그대로 맞춰졌구요 (예: insertImage -> insert),
get 함수만 예외적으로 로컬은 get 땡땡 byId, 원격은 getRemote 땡땡 이렇게 나눴습니다
-> 로컬도 getLocal~ 이렇게 하는 게 나을지 고민되는데, 의견 나눠주시면 감사하겠습니다

순서는 CRUD (insert, get, update, delete) 순으로 했구요
각각에 대해 local -> remote 순으로 했습니다
별거 아닌 거 같지만 이런 거 정리해놓는 게 나중에 알아보기 편한 거 같아요

**** 추가 수정사항 (언젠가 해야 될 것들 미루다가 해치웠습니다..)
- 주한님 피드백 반영해 불필요한 슬래시 제거
- RepositoryImpl 리턴타입 생략 (함수별 리턴타입은 Repository에 명시돼 있음)
- 데이터 클래스 변환 함수에서 디스트럭처링 할당 생략
- Place 관련 프로퍼티명 plan -> isPlan 수정
- Entity 마지막 프로퍼티 순서 remoteId, localId에서 localId, remoteId로 변경 (DTO와 순서 통일)
- 쿼리 프로퍼티명에 Entity, DTO 등 생략 (예: insert(id: String, user: UserDTO)) -> 이건 특별한 이유는 없는데 처음 local DB 함수들 구현했을 때 그렇게 해놓아서 할 거면 다 user로 하든, userEntity/userDTO로 하든 통일하는 게 맞을 거 같구요, 추가적으로 파라미터명은 심플하게 가져가는 게 좋아 보이는 것도 있습니다, 예를 들어 파라미터명은 id로 하지, remoteUserId 이렇게 길게 안 하니까요

이거 머지하고 나서 리베이스하게 되면 빡셀 수도 있으니 도움 필요하신 분은 알려주세요
그리고 추가 피드백이나 의견 있으시면 공유해주세요!