### PR TITLE
[전역] 하드코드디 스트링 및 정수 값들을 상수 혹은 스트링 리소스로 추출

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -117,6 +117,11 @@ dependencies {
 
     implementation("androidx.swiperefreshlayout:swiperefreshlayout:1.2.0-alpha01")
     implementation("androidx.paging:paging-runtime-ktx:3.2.1")
+
+    implementation("androidx.hilt:hilt-work:1.2.0-beta01")
+    ksp("androidx.hilt:hilt-compiler:1.2.0-beta01")
+
+    implementation(kotlin("reflect"))
 }
 
 kapt {

--- a/app/src/main/java/com/treasurehunt/data/remote/ImageService.kt
+++ b/app/src/main/java/com/treasurehunt/data/remote/ImageService.kt
@@ -8,14 +8,16 @@ import retrofit2.http.GET
 import retrofit2.http.POST
 import retrofit2.http.Path
 
+internal const val REMOTE_DATABASE_IMAGES = "images"
+
 interface ImageService {
 
-    @POST("images.json")
+    @POST("$REMOTE_DATABASE_IMAGES.json")
     suspend fun insert(@Body image: ImageDTO): RemoteIdWrapper
 
-    @GET("images/{id}.json")
+    @GET("$REMOTE_DATABASE_IMAGES/{id}.json")
     suspend fun getRemoteImageById(@Path("id") id: String): ImageDTO
 
-    @DELETE("images/{id}.json")
+    @DELETE("$REMOTE_DATABASE_IMAGES/{id}.json")
     suspend fun delete(@Path("id") id: String)
 }

--- a/app/src/main/java/com/treasurehunt/data/remote/LogService.kt
+++ b/app/src/main/java/com/treasurehunt/data/remote/LogService.kt
@@ -9,23 +9,25 @@ import retrofit2.http.PATCH
 import retrofit2.http.POST
 import retrofit2.http.Path
 
+internal const val REMOTE_DATABASE_LOGS = "logs"
+
 interface LogService {
 
-    @POST("logs.json")
+    @POST("$REMOTE_DATABASE_LOGS.json")
     suspend fun insert(@Body log: LogDTO): RemoteIdWrapper
 
-    @GET("logs/{id}.json")
+    @GET("$REMOTE_DATABASE_LOGS/{id}.json")
     suspend fun getRemoteLogById(@Path("id") id: String): LogDTO
 
-    @GET("logs.json")
+    @GET("$REMOTE_DATABASE_LOGS.json")
     suspend fun getAllRemoteLogs(): List<LogDTO>
 
-    @PATCH("logs/{id}.json")
+    @PATCH("$REMOTE_DATABASE_LOGS/{id}.json")
     suspend fun update(
         @Path("id") id: String,
         @Body log: LogDTO
     )
 
-    @DELETE("logs/{id}.json")
+    @DELETE("$REMOTE_DATABASE_LOGS/{id}.json")
     suspend fun delete(@Path("id") id: String)
 }

--- a/app/src/main/java/com/treasurehunt/data/remote/PlaceService.kt
+++ b/app/src/main/java/com/treasurehunt/data/remote/PlaceService.kt
@@ -9,20 +9,22 @@ import retrofit2.http.PATCH
 import retrofit2.http.POST
 import retrofit2.http.Path
 
+internal const val REMOTE_DATABASE_PLACES = "places"
+
 interface PlaceService {
 
-    @POST("places.json")
+    @POST("$REMOTE_DATABASE_PLACES.json")
     suspend fun insert(@Body place: PlaceDTO): RemoteIdWrapper
 
-    @GET("places/{id}.json")
+    @GET("$REMOTE_DATABASE_PLACES/{id}.json")
     suspend fun getRemotePlaceById(@Path("id") id: String): PlaceDTO
 
-    @PATCH("places/{id}.json")
+    @PATCH("$REMOTE_DATABASE_PLACES/{id}.json")
     suspend fun update(
         @Path("id") id: String,
         @Body place: PlaceDTO
     )
 
-    @DELETE("places/{id}.json")
+    @DELETE("$REMOTE_DATABASE_PLACES/{id}.json")
     suspend fun delete(@Path("id") id: String)
 }

--- a/app/src/main/java/com/treasurehunt/data/remote/UserService.kt
+++ b/app/src/main/java/com/treasurehunt/data/remote/UserService.kt
@@ -13,22 +13,22 @@ internal const val REMOTE_DATABASE_USERS = "users"
 
 interface UserService {
 
-    @PUT("users/{id}.json")
+    @PUT("$REMOTE_DATABASE_USERS/{id}.json")
     suspend fun insert(
         @Path("id") id: String,
         @Body user: UserDTO
     )
 
-    @GET("users/{id}.json")
+    @GET("$REMOTE_DATABASE_USERS/{id}.json")
     suspend fun getRemoteUserById(@Path("id") id: String): UserDTO
 
-    @PATCH("users/{id}.json")
+    @PATCH("$REMOTE_DATABASE_USERS/{id}.json")
     suspend fun update(
         @Path("id") id: String,
         @Body user: UserDTO
     )
 
-    @GET("users.json")
+    @GET("$REMOTE_DATABASE_USERS.json")
     suspend fun search(
         @Query("orderBy") orderBy: String,
         @Query("startAt") startAt: String,

--- a/app/src/main/java/com/treasurehunt/data/remote/UserService.kt
+++ b/app/src/main/java/com/treasurehunt/data/remote/UserService.kt
@@ -9,6 +9,8 @@ import retrofit2.http.PUT
 import retrofit2.http.Path
 import retrofit2.http.Query
 
+internal const val REMOTE_DATABASE_USERS = "users"
+
 interface UserService {
 
     @PUT("users/{id}.json")

--- a/app/src/main/java/com/treasurehunt/ui/detail/LogDetailViewModel.kt
+++ b/app/src/main/java/com/treasurehunt/ui/detail/LogDetailViewModel.kt
@@ -17,12 +17,16 @@ import com.treasurehunt.data.remote.model.toMapSymbol
 import com.treasurehunt.data.remote.model.toPlaceEntity
 import com.treasurehunt.ui.model.LogModel
 import com.treasurehunt.ui.model.MapSymbol
+import com.treasurehunt.util.STORAGE_LOCATION_LOG_IMAGES
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
+
+private const val STORAGE_LOCATION_USER_IMAGES = "%s/$STORAGE_LOCATION_LOG_IMAGES"
+private const val IMAGE_FILE_NAME_PREFIX = "$STORAGE_LOCATION_LOG_IMAGES/"
 
 @HiltViewModel
 class LogDetailViewModel @Inject constructor(
@@ -81,9 +85,12 @@ class LogDetailViewModel @Inject constructor(
 
     private suspend fun deleteImages(logId: String, userId: String) {
         val remoteLog = logRepo.getRemoteLogById(logId)
-        val storageRef = Firebase.storage.reference.child("${userId}/log_images")
+        val storageRef = Firebase.storage.getReference(
+            String.format(STORAGE_LOCATION_USER_IMAGES, userId)
+        )
         remoteLog.remoteImageIds.filterValues { it }.keys.forEach { id ->
-            val imageFileName = imageRepo.getRemoteImageById(id).url.substringAfter("log_images/")
+            val imageFileName = imageRepo.getRemoteImageById(id).url
+                .substringAfter(IMAGE_FILE_NAME_PREFIX)
             storageRef.child("/$imageFileName").delete()
             imageRepo.delete(id)
         }

--- a/app/src/main/java/com/treasurehunt/ui/home/HomeActivity.kt
+++ b/app/src/main/java/com/treasurehunt/ui/home/HomeActivity.kt
@@ -13,13 +13,15 @@ import androidx.navigation.fragment.NavHostFragment
 import androidx.navigation.ui.setupWithNavController
 import com.treasurehunt.R
 import com.treasurehunt.databinding.ActivityHomeBinding
-import com.treasurehunt.util.UPLOAD_NOTIFICATION_ID_STRING
 import dagger.hilt.android.AndroidEntryPoint
+
+internal const val UPLOAD_NOTIFICATION_CHANNEL_ID = "Upload"
 
 @AndroidEntryPoint
 class HomeActivity : AppCompatActivity() {
 
     private lateinit var binding: ActivityHomeBinding
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         binding = ActivityHomeBinding.inflate(layoutInflater)
@@ -58,11 +60,11 @@ class HomeActivity : AppCompatActivity() {
     private fun createNotificationChannel() {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             val name = getString(R.string.notification_channel)
-            val descriptionText = getString(R.string.notification_description)
             val importance = NotificationManager.IMPORTANCE_DEFAULT
+            val description = getString(R.string.notification_description)
             val channel =
-                NotificationChannel(UPLOAD_NOTIFICATION_ID_STRING, name, importance).apply {
-                    description = descriptionText
+                NotificationChannel(UPLOAD_NOTIFICATION_CHANNEL_ID, name, importance).apply {
+                    this.description = description
                 }
             val notificationManager =
                 getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager

--- a/app/src/main/java/com/treasurehunt/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/treasurehunt/ui/home/HomeFragment.kt
@@ -4,7 +4,6 @@ import android.Manifest
 import android.content.pm.PackageManager
 import android.graphics.PointF
 import android.os.Bundle
-import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup

--- a/app/src/main/java/com/treasurehunt/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/treasurehunt/ui/home/HomeViewModel.kt
@@ -29,6 +29,11 @@ import kotlinx.coroutines.launch
 import java.io.IOException
 import javax.inject.Inject
 
+private const val VISIT_MARKER_WIDTH = 116
+private const val VISIT_MARKER_HEIGHT = 80
+private const val PLAN_MARKER_WIDTH = 96
+private const val PLAN_MARKER_HEIGHT = 80
+
 @HiltViewModel
 class HomeViewModel @Inject constructor(
     private val logRepo: LogRepository,
@@ -103,7 +108,10 @@ class HomeViewModel @Inject constructor(
 
         fetchJob = viewModelScope.launch {
             try {
-                combine(placeRepo.getAllLocalVisits(), placeRepo.getAllLocalPlans()) { visits, plans ->
+                combine(
+                    placeRepo.getAllLocalVisits(),
+                    placeRepo.getAllLocalPlans()
+                ) { visits, plans ->
                     visits + plans
                 }
                     .stateIn(viewModelScope, SharingStarted.WhileSubscribed(), emptyList())
@@ -134,16 +142,16 @@ class HomeViewModel @Inject constructor(
                 place.remoteId,
                 place.caption,
                 OverlayImage.fromResource(R.drawable.ic_chest_open),
-                116,
-                80
+                VISIT_MARKER_WIDTH,
+                VISIT_MARKER_HEIGHT
             )
         } else {
             Marker(LatLng(place.lat, place.lng)).from(
                 place.remoteId,
                 place.caption,
                 OverlayImage.fromResource(R.drawable.ic_chest_closed),
-                96,
-                80
+                PLAN_MARKER_WIDTH,
+                PLAN_MARKER_HEIGHT
             )
         }
     }

--- a/app/src/main/java/com/treasurehunt/ui/profile/FriendAdapter.kt
+++ b/app/src/main/java/com/treasurehunt/ui/profile/FriendAdapter.kt
@@ -11,6 +11,8 @@ import com.treasurehunt.R
 import com.treasurehunt.databinding.ItemFriendBinding
 import com.treasurehunt.ui.model.UserModel
 
+private const val AT_SIGN = '@'
+
 class FriendAdapter(
     private val friendClickListener: FriendClickListener,
     private val isClickable: Boolean
@@ -38,7 +40,7 @@ class FriendAdapter(
         ) {
             bindImage(binding.ivProfileImage, friend.profileImage)
             binding.tvNickname.text = friend.nickName
-            binding.tvEmail.text = friend.email.toString().substringBefore('@')
+            binding.tvEmail.text = friend.email.toString().substringBefore(AT_SIGN)
 
             _isClickable = isClickable
             binding.ibRemove.setOnClickListener {

--- a/app/src/main/java/com/treasurehunt/ui/profile/FriendViewModel.kt
+++ b/app/src/main/java/com/treasurehunt/ui/profile/FriendViewModel.kt
@@ -1,6 +1,5 @@
 package com.treasurehunt.ui.profile
 
-import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.google.firebase.FirebaseException
@@ -18,7 +17,7 @@ import com.treasurehunt.data.remote.REMOTE_DATABASE_USERS
 import com.treasurehunt.data.remote.model.UserDTO
 import com.treasurehunt.data.remote.model.toUserModel
 import com.treasurehunt.ui.model.FriendUiState
-import com.treasurehunt.util.COMPILATION_WARNING_UNCHECKED_CAST_
+import com.treasurehunt.util.COMPILATION_WARNING_UNCHECKED_CAST
 import com.treasurehunt.util.ConnectivityRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.async
@@ -62,7 +61,7 @@ class FriendViewModel @Inject constructor(
         val friendsRef =
             db.reference.child(REMOTE_DATABASE_USERS).child(uid).child(pathStringFriends)
         val callback = object : ValueEventListener {
-            @Suppress(COMPILATION_WARNING_UNCHECKED_CAST_)
+            @Suppress(COMPILATION_WARNING_UNCHECKED_CAST)
             override fun onDataChange(snapshot: DataSnapshot) {
                 val friendIds = (snapshot.value as? Map<String, Boolean>
                     ?: emptyMap()).filter { it.value }.keys.toList()

--- a/app/src/main/java/com/treasurehunt/ui/profile/FriendViewModel.kt
+++ b/app/src/main/java/com/treasurehunt/ui/profile/FriendViewModel.kt
@@ -1,5 +1,6 @@
 package com.treasurehunt.ui.profile
 
+import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.google.firebase.FirebaseException
@@ -13,9 +14,11 @@ import com.treasurehunt.BuildConfig
 import com.treasurehunt.data.LogRepository
 import com.treasurehunt.data.PlaceRepository
 import com.treasurehunt.data.UserRepository
+import com.treasurehunt.data.remote.REMOTE_DATABASE_USERS
 import com.treasurehunt.data.remote.model.UserDTO
 import com.treasurehunt.data.remote.model.toUserModel
 import com.treasurehunt.ui.model.FriendUiState
+import com.treasurehunt.util.COMPILATION_WARNING_UNCHECKED_CAST_
 import com.treasurehunt.util.ConnectivityRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.async
@@ -32,6 +35,7 @@ import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 private const val BASE_URL = BuildConfig.BASE_URL
+private val pathStringFriends = UserDTO::remoteFriendIds.name
 
 @HiltViewModel
 class FriendViewModel @Inject constructor(
@@ -55,9 +59,10 @@ class FriendViewModel @Inject constructor(
 
     private fun getFriendIdsFlow(): Flow<List<String>> = callbackFlow {
         val uid = Firebase.auth.currentUser!!.uid
-        val friendsRef = db.reference.child("users").child(uid).child("friends")
+        val friendsRef =
+            db.reference.child(REMOTE_DATABASE_USERS).child(uid).child(pathStringFriends)
         val callback = object : ValueEventListener {
-            @Suppress("UNCHECKED_CAST")
+            @Suppress(COMPILATION_WARNING_UNCHECKED_CAST_)
             override fun onDataChange(snapshot: DataSnapshot) {
                 val friendIds = (snapshot.value as? Map<String, Boolean>
                     ?: emptyMap()).filter { it.value }.keys.toList()

--- a/app/src/main/java/com/treasurehunt/ui/profile/ProfileFragment.kt
+++ b/app/src/main/java/com/treasurehunt/ui/profile/ProfileFragment.kt
@@ -20,14 +20,13 @@ import com.google.firebase.storage.storage
 import com.treasurehunt.R
 import com.treasurehunt.data.remote.model.UserDTO
 import com.treasurehunt.databinding.FragmentProfileBinding
+import com.treasurehunt.util.FILENAME_EXTENSION_PNG
 import com.treasurehunt.util.STORAGE_LOCATION_PROFILE_IMAGE
 import com.treasurehunt.util.showSnackbar
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.tasks.await
 
-private const val STORAGE_LOCATION_USER_PROFILE_IMAGE = "%s/$STORAGE_LOCATION_PROFILE_IMAGE"
-private const val PATH_STRING_FILE_NAME = "%s.png"
 private const val NULL_STRING = "null"
 
 @AndroidEntryPoint
@@ -140,15 +139,10 @@ class ProfileFragment : Fragment() {
 
     private suspend fun uploadProfileImage(uri: Uri) {
         val uid = Firebase.auth.currentUser!!.uid
-        val storage = Firebase.storage
-        val storageRef = storage.getReference(
-            String.format(STORAGE_LOCATION_USER_PROFILE_IMAGE, uid)
-        )
-        val fileName = uri.toString().extractDigits()
-        val fileRef = storageRef.child(
-            String.format(PATH_STRING_FILE_NAME, fileName)
-        )
-        val uploadTask = fileRef.putFile(uri)
+        val filename = uri.toString().extractDigits()
+        val profileImageStorageRef = Firebase.storage.reference.child(uid).child(STORAGE_LOCATION_PROFILE_IMAGE)
+            .child("$filename$FILENAME_EXTENSION_PNG")
+        val uploadTask = profileImageStorageRef.putFile(uri)
         uploadTask.addOnSuccessListener { taskSnapshot ->
             viewModel.setProfileUri(taskSnapshot.storage.toString())
         }.addOnFailureListener {

--- a/app/src/main/java/com/treasurehunt/ui/profile/ProfileFragment.kt
+++ b/app/src/main/java/com/treasurehunt/ui/profile/ProfileFragment.kt
@@ -27,6 +27,7 @@ import kotlinx.coroutines.tasks.await
 
 @AndroidEntryPoint
 class ProfileFragment : Fragment() {
+
     private var _binding: FragmentProfileBinding? = null
     private val binding get() = _binding!!
     private val viewModel: ProfileViewModel by viewModels()

--- a/app/src/main/java/com/treasurehunt/ui/profile/ProfileFragment.kt
+++ b/app/src/main/java/com/treasurehunt/ui/profile/ProfileFragment.kt
@@ -20,12 +20,13 @@ import com.google.firebase.storage.storage
 import com.treasurehunt.R
 import com.treasurehunt.data.remote.model.UserDTO
 import com.treasurehunt.databinding.FragmentProfileBinding
+import com.treasurehunt.util.STORAGE_LOCATION_PROFILE_IMAGE
 import com.treasurehunt.util.showSnackbar
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.tasks.await
 
-private const val STORAGE_LOCATION_PROFILE_IMAGE = "%s/profile_image"
+private const val STORAGE_LOCATION_USER_PROFILE_IMAGE = "%s/$STORAGE_LOCATION_PROFILE_IMAGE"
 private const val PATH_STRING_FILE_NAME = "%s.png"
 private const val NULL_STRING = "null"
 
@@ -141,7 +142,7 @@ class ProfileFragment : Fragment() {
         val uid = Firebase.auth.currentUser!!.uid
         val storage = Firebase.storage
         val storageRef = storage.getReference(
-            String.format(STORAGE_LOCATION_PROFILE_IMAGE, uid)
+            String.format(STORAGE_LOCATION_USER_PROFILE_IMAGE, uid)
         )
         val fileName = uri.toString().extractDigits()
         val fileRef = storageRef.child(

--- a/app/src/main/java/com/treasurehunt/ui/profile/ProfileFragment.kt
+++ b/app/src/main/java/com/treasurehunt/ui/profile/ProfileFragment.kt
@@ -22,6 +22,7 @@ import com.treasurehunt.data.remote.model.UserDTO
 import com.treasurehunt.databinding.FragmentProfileBinding
 import com.treasurehunt.util.FILENAME_EXTENSION_PNG
 import com.treasurehunt.util.STORAGE_LOCATION_PROFILE_IMAGE
+import com.treasurehunt.util.extractDigits
 import com.treasurehunt.util.showSnackbar
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
@@ -150,8 +151,6 @@ class ProfileFragment : Fragment() {
         }
         uploadTask.await()
     }
-
-    private fun String.extractDigits() = replace("[^0-9]".toRegex(), "")
 
     private fun saveProfile() {
         lifecycleScope.launch {

--- a/app/src/main/java/com/treasurehunt/ui/profile/ProfileViewModel.kt
+++ b/app/src/main/java/com/treasurehunt/ui/profile/ProfileViewModel.kt
@@ -1,6 +1,7 @@
 package com.treasurehunt.ui.profile
 
 import android.content.Intent
+import android.provider.MediaStore
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
@@ -9,6 +10,7 @@ import com.google.firebase.Firebase
 import com.google.firebase.auth.auth
 import com.treasurehunt.data.UserRepository
 import com.treasurehunt.data.remote.model.UserDTO
+import com.treasurehunt.util.MIME_TYPE_IMAGE
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -28,10 +30,8 @@ class ProfileViewModel @Inject constructor(
         _profileUri.value = profileUri
     }
 
-    fun getImage(): Intent {
-        return Intent(Intent.ACTION_PICK).apply {
-            type = "image/"
-        }
+    fun getImage() = Intent(Intent.ACTION_PICK, MediaStore.Images.Media.EXTERNAL_CONTENT_URI).apply {
+        type = MIME_TYPE_IMAGE
     }
 
     fun addImage(image: String) {

--- a/app/src/main/java/com/treasurehunt/ui/savelog/ImageUploadWorker.kt
+++ b/app/src/main/java/com/treasurehunt/ui/savelog/ImageUploadWorker.kt
@@ -24,6 +24,7 @@ import com.treasurehunt.data.remote.model.LogDTO
 import com.treasurehunt.ui.home.UPLOAD_NOTIFICATION_CHANNEL_ID
 import com.treasurehunt.util.FILENAME_EXTENSION_PNG
 import com.treasurehunt.util.STORAGE_LOCATION_LOG_IMAGES
+import com.treasurehunt.util.extractDigits
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
 import kotlinx.coroutines.tasks.await
@@ -140,8 +141,6 @@ class ImageUploadWorker @AssistedInject constructor(
             imagesStorageRef.child("$filename$FILENAME_EXTENSION_PNG")
         }
     }
-
-    private fun String.extractDigits() = replace("[^0-9]".toRegex(), "")
 
     private fun execUploadTasks(uris: List<Uri>, refs: List<StorageReference>): List<UploadTask> {
         return uris.mapIndexed { i, uri ->

--- a/app/src/main/java/com/treasurehunt/ui/savelog/ImageUploadWorker.kt
+++ b/app/src/main/java/com/treasurehunt/ui/savelog/ImageUploadWorker.kt
@@ -21,11 +21,12 @@ import com.treasurehunt.R
 import com.treasurehunt.data.ImageRepository
 import com.treasurehunt.data.LogRepository
 import com.treasurehunt.data.remote.model.LogDTO
-import com.treasurehunt.util.UPLOAD_NOTIFICATION_ID
-import com.treasurehunt.util.UPLOAD_NOTIFICATION_ID_STRING
+import com.treasurehunt.ui.home.UPLOAD_NOTIFICATION_CHANNEL_ID
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
 import kotlinx.coroutines.tasks.await
+
+private const val UPLOAD_NOTIFICATION_ID = 0
 
 @HiltWorker
 class ImageUploadWorker @AssistedInject constructor(
@@ -174,7 +175,7 @@ class ImageUploadWorker @AssistedInject constructor(
         val pendingIntent =
             PendingIntent.getActivity(context, 0, launchIntent, PendingIntent.FLAG_IMMUTABLE)
 
-        return NotificationCompat.Builder(context, UPLOAD_NOTIFICATION_ID_STRING)
+        return NotificationCompat.Builder(context, UPLOAD_NOTIFICATION_CHANNEL_ID)
             .setSmallIcon(R.drawable.ic_chest_open)
             .setContentTitle(context.getString(R.string.savelog_image_upload_notification_title))
             .setContentText(context.getString(R.string.savelog_image_upload_notification_progress))

--- a/app/src/main/java/com/treasurehunt/ui/savelog/ImageUploadWorker.kt
+++ b/app/src/main/java/com/treasurehunt/ui/savelog/ImageUploadWorker.kt
@@ -27,6 +27,8 @@ import dagger.assisted.AssistedInject
 import kotlinx.coroutines.tasks.await
 
 private const val UPLOAD_NOTIFICATION_ID = 0
+private const val STORAGE_LOCATION_IMAGES = "%s/log_images"
+private const val PATH_STRING_FILE_NAME = "%s.png"
 
 @HiltWorker
 class ImageUploadWorker @AssistedInject constructor(
@@ -127,15 +129,21 @@ class ImageUploadWorker @AssistedInject constructor(
     }
 
     private fun getStorageReferences(uid: String, uris: List<Uri>): List<StorageReference> {
-        val storageRef = Firebase.storage.getReference("${uid}/log_images")
+        val storageRef = Firebase.storage.getReference(
+            String.format(STORAGE_LOCATION_IMAGES, uid)
+        )
         val fileNames = uris.map {
-            it.toString().replace("[^0-9]".toRegex(), "")
+            it.toString().extractDigits()
         }
 
         return fileNames.map {
-            storageRef.child("$it.png")
+            storageRef.child(
+                String.format(PATH_STRING_FILE_NAME, it)
+            )
         }
     }
+
+    private fun String.extractDigits() = replace("[^0-9]".toRegex(), "")
 
     private fun execUploadTasks(uris: List<Uri>, refs: List<StorageReference>): List<UploadTask> {
         return uris.mapIndexed { i, uri ->

--- a/app/src/main/java/com/treasurehunt/ui/savelog/SaveLogMapFragment.kt
+++ b/app/src/main/java/com/treasurehunt/ui/savelog/SaveLogMapFragment.kt
@@ -17,6 +17,8 @@ import com.naver.maps.map.util.FusedLocationSource
 import com.treasurehunt.R
 import com.treasurehunt.databinding.FragmentSavelogMapBinding
 
+private const val LOCATION_PERMISSION_REQUEST_CODE = 1002
+
 class SaveLogMapFragment : Fragment(), OnMapReadyCallback {
 
     private var _binding: FragmentSavelogMapBinding? = null
@@ -96,9 +98,5 @@ class SaveLogMapFragment : Fragment(), OnMapReadyCallback {
     override fun onMapReady(naverMap: NaverMap) {
         initMap(naverMap)
         handleLocationAccessPermission()
-    }
-
-    companion object {
-        private const val LOCATION_PERMISSION_REQUEST_CODE = 1002
     }
 }

--- a/app/src/main/java/com/treasurehunt/ui/savelog/SaveLogViewModel.kt
+++ b/app/src/main/java/com/treasurehunt/ui/savelog/SaveLogViewModel.kt
@@ -13,6 +13,8 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.update
 import javax.inject.Inject
 
+private const val MIME_TYPE_IMAGE = "image/*"
+
 @HiltViewModel
 class SaveLogViewModel @Inject constructor(private val imageRepo: ImageRepository) : ViewModel() {
 
@@ -21,7 +23,7 @@ class SaveLogViewModel @Inject constructor(private val imageRepo: ImageRepositor
 
     fun getImagePick() =
         Intent(Intent.ACTION_PICK, MediaStore.Images.Media.EXTERNAL_CONTENT_URI).apply {
-            type = "image/*"
+            type = MIME_TYPE_IMAGE
             putExtra(Intent.EXTRA_ALLOW_MULTIPLE, true)
         }
 

--- a/app/src/main/java/com/treasurehunt/ui/savelog/SaveLogViewModel.kt
+++ b/app/src/main/java/com/treasurehunt/ui/savelog/SaveLogViewModel.kt
@@ -7,13 +7,12 @@ import com.treasurehunt.data.ImageRepository
 import com.treasurehunt.data.remote.model.LogDTO
 import com.treasurehunt.ui.model.ImageModel
 import com.treasurehunt.ui.model.SaveLogUiState
+import com.treasurehunt.util.MIME_TYPE_IMAGE
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.update
 import javax.inject.Inject
-
-private const val MIME_TYPE_IMAGE = "image/*"
 
 @HiltViewModel
 class SaveLogViewModel @Inject constructor(private val imageRepo: ImageRepository) : ViewModel() {

--- a/app/src/main/java/com/treasurehunt/util/Constants.kt
+++ b/app/src/main/java/com/treasurehunt/util/Constants.kt
@@ -1,6 +1,6 @@
 package com.treasurehunt.util
 
-internal const val COMPILATION_WARNING_UNCHECKED_CAST_ = "UNCHECKED_CAST"
+internal const val COMPILATION_WARNING_UNCHECKED_CAST = "UNCHECKED_CAST"
 
 internal const val STORAGE_LOCATION_LOG_IMAGES = "log_images"
 

--- a/app/src/main/java/com/treasurehunt/util/Constants.kt
+++ b/app/src/main/java/com/treasurehunt/util/Constants.kt
@@ -1,3 +1,7 @@
 package com.treasurehunt.util
 
 internal const val COMPILATION_WARNING_UNCHECKED_CAST_ = "UNCHECKED_CAST"
+
+internal const val STORAGE_LOCATION_LOG_IMAGES = "log_images"
+
+internal const val STORAGE_LOCATION_PROFILE_IMAGE = "profile_image"

--- a/app/src/main/java/com/treasurehunt/util/Constants.kt
+++ b/app/src/main/java/com/treasurehunt/util/Constants.kt
@@ -1,5 +1,3 @@
 package com.treasurehunt.util
 
-internal val UPLOAD_NOTIFICATION_ID = 0
-
-internal val UPLOAD_NOTIFICATION_ID_STRING = "Upload"
+internal const val COMPILATION_WARNING_UNCHECKED_CAST_ = "UNCHECKED_CAST"

--- a/app/src/main/java/com/treasurehunt/util/Constants.kt
+++ b/app/src/main/java/com/treasurehunt/util/Constants.kt
@@ -5,3 +5,7 @@ internal const val COMPILATION_WARNING_UNCHECKED_CAST = "UNCHECKED_CAST"
 internal const val STORAGE_LOCATION_LOG_IMAGES = "log_images"
 
 internal const val STORAGE_LOCATION_PROFILE_IMAGE = "profile_image"
+
+internal const val FILENAME_EXTENSION_PNG = ".png"
+
+internal const val MIME_TYPE_IMAGE = "image/*"

--- a/app/src/main/java/com/treasurehunt/util/Extensions.kt
+++ b/app/src/main/java/com/treasurehunt/util/Extensions.kt
@@ -4,11 +4,7 @@ import android.view.View
 import com.google.android.material.snackbar.Snackbar
 import kotlinx.serialization.json.Json
 
-private val json = Json {
-    isLenient = true
-    ignoreUnknownKeys = true
-    coerceInputValues = true
-}
+//******************** View ********************
 
 fun View.showSnackbar(resId: Int) {
     Snackbar.make(
@@ -26,8 +22,6 @@ fun View.showSnackbar(string: String) {
     ).show()
 }
 
-internal inline fun <reified R> String.convertToDataClass() = json.decodeFromString<R>(this)
-
 fun View.show() {
     visibility = View.VISIBLE
 }
@@ -35,3 +29,16 @@ fun View.show() {
 fun View.hide() {
     visibility = View.GONE
 }
+
+
+//******************** String ********************
+
+internal inline fun <reified R> String.convertToDataClass() = json.decodeFromString<R>(this)
+
+private val json = Json {
+    isLenient = true
+    ignoreUnknownKeys = true
+    coerceInputValues = true
+}
+
+internal fun String.extractDigits() = replace("[^0-9]".toRegex(), "")

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -41,8 +41,11 @@
     <string name="savelog_image_upload_notification_fail">업로드 실패</string>
 
     <!-- 기록 상세 화면 -->
-    <string name="Logdetail_content">Check out Treasure Hunt: %s</string>
-    <string name="Logdetail_chooser_title">내용 공유하기</string>
+    <string name="logdetail_content">Check out Treasure Hunt: %s</string>
+    <string name="logdetail_chooser_title">내용 공유하기</string>
+    <string name="logdetail_log_still_loading_message">데이터를 불러오는 중입니다. 잠시 후 다시 시도해 주세요</string>
+    <string name="logdetail_log_deleted_message">기록이 삭제되었습니다</string>
+    <string name="logdetail_error_message">문제가 생겨 잠시 후 다시 시도해 주세요</string>
 
     <!-- 프로필 화면-->
     <string name="profile_tv_nickname">닉네임</string>


### PR DESCRIPTION
코드에서 사용되는 스트링 값들은 탑레벨 상수에 담아두고 관리하는 게 권장되어서 언젠가 해야지 하던 작업들을 한번에 처리했습니다
상수의 장점에 대해서는 이 글 참고해주세요
https://stackoverflow.com/questions/4234129/should-i-use-constants-instead-of-strings-even-if-the-strings-are-only-ever-used
그리고 UI에 사용되는 스트링 값들은 xml의 스트링 리소스로 분리하는 거랑 이거랑 헷갈릴 수 있는데, 궁금한 거 있으면 물어봐주세요~

미뤄두다 이번에 하게 된 계기는, 제가 저번에 UserDTO의 프로퍼티명을 friends -> remoteFriendIds로 변경했는데,
FriendViewModel에서 하드코드디 스트링으로 ("friends") 파이어베이스 DB의 위치를 참조해 레퍼런스를 생성 중인 걸 우연히 보게 되어서입니다
val friendsRef = db.reference.child("users).child(uid).child("friends")
따라서 위의 코드가 아래처럼 수정되었습니다
val friendsRef = db.reference.child(REMOTE_DATABASE_USERS).child(uid).child(pathStringFriends)
이런 식으로 값의 변경이 있을 때, 그 값의 사용처를 일일이 찾아 변경해줄 필요 없이 일괄 관리하는 장점이 있습니다
파이어베이스 테이블명(가령 users)를 바꿀 일이 있을진 모르겠지만, 이것도 같은 맥락으로 일괄 관리하는 게 더 효율적으로 보여 동일하게 상수로 추출했습니다

-- 추가 수정사항 및 피드백 반영 --
- StorageReference 생성 방식을 String.format 대신 child 함수 체이닝으로 수정
- 프로필 화면에서 프로필 사진 수정시 기기 앨범 사진 불러오는 기능 누락 오류 해결
- 문자열에서 숫자 추출 확장 함수 Extensions 파일로 이동