### PR TITLE
[전역] ViewModel StateFlow 프로퍼티를 asStateFlow() 함수로 생성 & ui별 adapter 패키지 분리

### DIFF
--- a/app/src/main/java/com/treasurehunt/ui/detail/LogDetailFragment.kt
+++ b/app/src/main/java/com/treasurehunt/ui/detail/LogDetailFragment.kt
@@ -3,7 +3,6 @@ package com.treasurehunt.ui.detail
 import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
-import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -19,6 +18,7 @@ import com.google.firebase.dynamiclinks.FirebaseDynamicLinks
 import com.google.firebase.ktx.Firebase
 import com.treasurehunt.R
 import com.treasurehunt.databinding.FragmentLogdetailBinding
+import com.treasurehunt.ui.detail.adapter.ImageSliderAdapter
 import com.treasurehunt.ui.model.LogModel
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch

--- a/app/src/main/java/com/treasurehunt/ui/detail/LogDetailViewModel.kt
+++ b/app/src/main/java/com/treasurehunt/ui/detail/LogDetailViewModel.kt
@@ -20,6 +20,7 @@ import com.treasurehunt.ui.model.MapSymbol
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -34,8 +35,8 @@ class LogDetailViewModel @Inject constructor(
 ) : ViewModel() {
 
     val args = LogDetailFragmentArgs.fromSavedStateHandle(savedStateHandle)
-    private val _log = MutableStateFlow<LogModel?>(null)
-    val log: StateFlow<LogModel?> = _log
+    private val _log: MutableStateFlow<LogModel?> = MutableStateFlow(null)
+    val log: StateFlow<LogModel?> = _log.asStateFlow()
 
     init {
         initLog()

--- a/app/src/main/java/com/treasurehunt/ui/detail/adapter/ImageSliderAdapter.kt
+++ b/app/src/main/java/com/treasurehunt/ui/detail/adapter/ImageSliderAdapter.kt
@@ -1,4 +1,4 @@
-package com.treasurehunt.ui.detail
+package com.treasurehunt.ui.detail.adapter
 
 import android.view.LayoutInflater
 import android.view.View
@@ -11,6 +11,7 @@ import com.bumptech.glide.Glide
 import com.google.firebase.storage.FirebaseStorage
 import com.treasurehunt.R
 import com.treasurehunt.databinding.ItemImageBinding
+import com.treasurehunt.ui.detail.ImageItem
 
 class ImageSliderAdapter :
     ListAdapter<ImageItem.Url, ImageSliderAdapter.ImageViewHolder>(ImageDiffCallback()) {

--- a/app/src/main/java/com/treasurehunt/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/treasurehunt/ui/home/HomeViewModel.kt
@@ -14,7 +14,7 @@ import com.treasurehunt.data.UserRepository
 import com.treasurehunt.data.local.model.PlaceEntity
 import com.treasurehunt.data.remote.model.PlaceDTO
 import com.treasurehunt.data.remote.model.UserDTO
-import com.treasurehunt.ui.model.MapUiState
+import com.treasurehunt.ui.model.HomeMapUiState
 import com.treasurehunt.util.ConnectivityRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Job
@@ -22,6 +22,7 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
@@ -38,8 +39,8 @@ class HomeViewModel @Inject constructor(
 ) :
     ViewModel() {
 
-    private val _uiState = MutableStateFlow(MapUiState())
-    val uiState: StateFlow<MapUiState> = _uiState
+    private val _uiState: MutableStateFlow<HomeMapUiState> = MutableStateFlow(HomeMapUiState())
+    val uiState: StateFlow<HomeMapUiState> = _uiState.asStateFlow()
     private var fetchJob: Job? = null
 
     init {

--- a/app/src/main/java/com/treasurehunt/ui/model/HomeMapUiState.kt
+++ b/app/src/main/java/com/treasurehunt/ui/model/HomeMapUiState.kt
@@ -1,9 +1,8 @@
 package com.treasurehunt.ui.model
 
 import com.naver.maps.map.overlay.Marker
-import com.treasurehunt.data.local.model.PlaceEntity
 
-data class MapUiState(
+data class HomeMapUiState(
     val uid: String? = null,
     val visitMarkers: List<Marker> = listOf(),
     val planMarkers: List<Marker> = listOf(),

--- a/app/src/main/java/com/treasurehunt/ui/profile/FriendFragment.kt
+++ b/app/src/main/java/com/treasurehunt/ui/profile/FriendFragment.kt
@@ -16,6 +16,8 @@ import com.treasurehunt.data.remote.model.UserDTO
 import com.treasurehunt.data.remote.model.toUserModel
 import com.treasurehunt.databinding.FragmentFriendBinding
 import com.treasurehunt.ui.model.UserModel
+import com.treasurehunt.ui.profile.adapter.FriendAdapter
+import com.treasurehunt.ui.profile.adapter.SearchFriendAdapter
 import com.treasurehunt.util.hide
 import com.treasurehunt.util.show
 import com.treasurehunt.util.showSnackbar

--- a/app/src/main/java/com/treasurehunt/ui/profile/FriendViewModel.kt
+++ b/app/src/main/java/com/treasurehunt/ui/profile/FriendViewModel.kt
@@ -25,6 +25,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
@@ -41,8 +42,8 @@ class FriendViewModel @Inject constructor(
     private val connectivityRepo: ConnectivityRepository
 ) : ViewModel() {
 
-    private val _uiState = MutableStateFlow(FriendUiState(false))
-    val uiState: StateFlow<FriendUiState> = _uiState
+    private val _uiState: MutableStateFlow<FriendUiState> = MutableStateFlow(FriendUiState(false))
+    val uiState: StateFlow<FriendUiState> = _uiState.asStateFlow()
     private val db = FirebaseDatabase.getInstance(BASE_URL)
     private val friendIds: Flow<List<String>> = getFriendIdsFlow()
 

--- a/app/src/main/java/com/treasurehunt/ui/profile/ProfileFragment.kt
+++ b/app/src/main/java/com/treasurehunt/ui/profile/ProfileFragment.kt
@@ -20,6 +20,7 @@ import com.google.firebase.storage.storage
 import com.treasurehunt.R
 import com.treasurehunt.data.remote.model.UserDTO
 import com.treasurehunt.databinding.FragmentProfileBinding
+import com.treasurehunt.ui.profile.adapter.ProfileViewPagerAdapter
 import com.treasurehunt.util.showSnackbar
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch

--- a/app/src/main/java/com/treasurehunt/ui/profile/ProfileViewModel.kt
+++ b/app/src/main/java/com/treasurehunt/ui/profile/ProfileViewModel.kt
@@ -17,6 +17,7 @@ import javax.inject.Inject
 class ProfileViewModel @Inject constructor(
     private val userRepository: UserRepository
 ) : ViewModel() {
+
     private val _userData: MutableLiveData<UserDTO> = MutableLiveData<UserDTO>()
     val userData: LiveData<UserDTO> = _userData
     private val _imageUri: MutableLiveData<String> = MutableLiveData<String>()

--- a/app/src/main/java/com/treasurehunt/ui/profile/ProfileViewPagerAdapter.kt
+++ b/app/src/main/java/com/treasurehunt/ui/profile/ProfileViewPagerAdapter.kt
@@ -5,6 +5,7 @@ import androidx.viewpager2.adapter.FragmentStateAdapter
 import com.treasurehunt.R
 
 class ProfileViewPagerAdapter(fragment: Fragment) : FragmentStateAdapter(fragment) {
+
     override fun getItemCount() = 3
 
     override fun createFragment(position: Int): Fragment {

--- a/app/src/main/java/com/treasurehunt/ui/profile/adapter/FriendAdapter.kt
+++ b/app/src/main/java/com/treasurehunt/ui/profile/adapter/FriendAdapter.kt
@@ -1,4 +1,4 @@
-package com.treasurehunt.ui.profile
+package com.treasurehunt.ui.profile.adapter
 
 import android.view.LayoutInflater
 import android.view.ViewGroup
@@ -10,6 +10,7 @@ import com.bumptech.glide.Glide
 import com.treasurehunt.R
 import com.treasurehunt.databinding.ItemFriendBinding
 import com.treasurehunt.ui.model.UserModel
+import com.treasurehunt.ui.profile.FriendClickListener
 
 class FriendAdapter(
     private val friendClickListener: FriendClickListener,

--- a/app/src/main/java/com/treasurehunt/ui/profile/adapter/ProfileViewPagerAdapter.kt
+++ b/app/src/main/java/com/treasurehunt/ui/profile/adapter/ProfileViewPagerAdapter.kt
@@ -1,8 +1,9 @@
-package com.treasurehunt.ui.profile
+package com.treasurehunt.ui.profile.adapter
 
 import androidx.fragment.app.Fragment
 import androidx.viewpager2.adapter.FragmentStateAdapter
 import com.treasurehunt.R
+import com.treasurehunt.ui.profile.FriendFragment
 
 class ProfileViewPagerAdapter(fragment: Fragment) : FragmentStateAdapter(fragment) {
 

--- a/app/src/main/java/com/treasurehunt/ui/profile/adapter/SearchFriendAdapter.kt
+++ b/app/src/main/java/com/treasurehunt/ui/profile/adapter/SearchFriendAdapter.kt
@@ -1,4 +1,4 @@
-package com.treasurehunt.ui.profile
+package com.treasurehunt.ui.profile.adapter
 
 import android.view.LayoutInflater
 import android.view.ViewGroup
@@ -10,6 +10,7 @@ import com.bumptech.glide.Glide
 import com.treasurehunt.R
 import com.treasurehunt.databinding.ItemSearchFriendBinding
 import com.treasurehunt.ui.model.UserModel
+import com.treasurehunt.ui.profile.FriendClickListener
 
 class SearchFriendAdapter(private val friendClickListener: FriendClickListener, private val isClickable: Boolean) :
     ListAdapter<UserModel, SearchFriendAdapter.ViewHolder>(diffUtil) {

--- a/app/src/main/java/com/treasurehunt/ui/savelog/SaveLogViewModel.kt
+++ b/app/src/main/java/com/treasurehunt/ui/savelog/SaveLogViewModel.kt
@@ -10,14 +10,15 @@ import com.treasurehunt.ui.model.SaveLogUiState
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import javax.inject.Inject
 
 @HiltViewModel
 class SaveLogViewModel @Inject constructor(private val imageRepo: ImageRepository) : ViewModel() {
 
-    private val _uiState = MutableStateFlow(SaveLogUiState())
-    val uiState: StateFlow<SaveLogUiState> = _uiState
+    private val _uiState: MutableStateFlow<SaveLogUiState> = MutableStateFlow(SaveLogUiState())
+    val uiState: StateFlow<SaveLogUiState> = _uiState.asStateFlow()
 
     fun getImagePick() =
         Intent(Intent.ACTION_PICK, MediaStore.Images.Media.EXTERNAL_CONTENT_URI).apply {


### PR DESCRIPTION
안드로이드 디벨로퍼 공식문서 예시에도 asStateFlow() 함수를 사용하고,
아래 스택오버플로 글 보면 왜 권장되는지 나와 있습니다 (대충 그거 없이 변수의 타입 지정만 해주면 MutableStateFlow로 타입 캐스팅해서 외부에서 값 변경이 가능해진다는 얘기)
https://stackoverflow.com/questions/73987849/what-is-the-difference-between-uistate-asstateflow-and-stateflowuistate
동현님은 피드 화면에 잘 적용해주셨는데, 저 포함해서 안 되 있는 부분들이 있어서 일괄 수정했습니다
그런데 이와 별개로,
1) 이건 굳이 다 통일시킬 필요는 없을 거 같은데, MutableStateFlow, StateFlow 프로퍼티들의 타입 명시를 어떻게 해주는 게 좋을지 고민이 돼서 일단 저는 둘다 명시하는 쪽으로 했습니다
공식문서는 StateFlow에만 타입 명시하고 있습니다
2) 이것도 통일할 필요는 없을 수도 있는데, MutableStateFlow의 초기값으로 null VS UiState() 이런 고민이 됐습니다
일단 공식문서는 후자를 택했고, 제가 예전에 동현님께 null이 나을 거 같다고 했는데, 저도 일단은 공식문서대로 후자로 하고는 있습니다

또 어답터 패키지 분리는 그동안 깜박하고 있었는데 아마 하기로 정했던 걸로 기억해 일괄 처리해주었습니다
3) 여기에 추가적으로 어답터 외에 clickListener, worker 등도 따로 내부패키지 분리하는 게 나을지 등 의견 나누면 좋을 거 같습니다
4) 그리고 현재는 UI 패키지 내에 model 패키지 만들어서 모델 관련 클래스들 다 담고 있는데, 프로젝트 구조 보면서 지금 드는 생각은, 각 화면별 패키지 내에 model 패키지를 만들어 관련된 클래스들을 해당 화면에서 관리하게 하는 게 더 찾기 쉬울 거 같다는 생각입니다

4가지 고민 사항에 대해서 한번 얘기 나눠보면 좋을 거 같습니다!
이번 주 중으로 오프든 디코든 미팅 함 하면서요~

-- 추가 사항 --
스트링 리팩토링 PR에 주한님 리뷰 보고 추가 논의사항 메모해둡니다
5) 변수, 함수, 클래스 등의 스코프를 최소화할지 한곳에서 관리해줄지