### PR TITLE
프로필 화면 비즈니스 로직 뷰모델로 이전 및 기타 리팩토링

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -85,7 +85,7 @@ dependencies {
     implementation("androidx.navigation:navigation-fragment-ktx:2.7.6")
     implementation("androidx.navigation:navigation-ui-ktx:2.7.6")
     implementation("androidx.fragment:fragment-ktx:1.6.2")
-    implementation("androidx.lifecycle:lifecycle-livedata-ktx:2.7.0")
+
     implementation("androidx.room:room-runtime:2.6.1")
     ksp("androidx.room:room-compiler:2.6.1")
     implementation("androidx.room:room-ktx:2.6.1")

--- a/app/src/main/java/com/treasurehunt/ui/home/HomeActivity.kt
+++ b/app/src/main/java/com/treasurehunt/ui/home/HomeActivity.kt
@@ -27,7 +27,6 @@ class HomeActivity : AppCompatActivity() {
         binding = ActivityHomeBinding.inflate(layoutInflater)
         setContentView(binding.root)
         initNavigation()
-        //handleDeepLink(intent)
 
         createNotificationChannel()
     }
@@ -71,28 +70,4 @@ class HomeActivity : AppCompatActivity() {
             notificationManager.createNotificationChannel(channel)
         }
     }
-
-    //TODO
-//    val SCHEME_TREASUREHUNT = "treasurehunt"
-//    val HOST_DETAIL = "detail"
-//    private fun handleDeepLink(intent: Intent?) {
-//        intent?.data?.let { uri ->
-//            if (uri.scheme == "SCHEME_TREASUREHUNT" && uri.host == "HOST_DETAIL") {
-//                val identifier = uri.lastPathSegment
-//                navigateToDetailFragmentWithIdentifier(identifier)
-//            }
-//        }
-//    }
-//
-//
-//    private fun navigateToDetailFragmentWithIdentifier(identifier: String?) {
-//        identifier?.let {
-//            val bundle = Bundle().apply {
-//                putString("contentId", it)
-//            }
-//            val navHostFragment =
-//                supportFragmentManager.findFragmentById(R.id.fcv_home) as NavHostFragment
-//            val navController = navHostFragment.navController
-//        }
-//    }
 }

--- a/app/src/main/java/com/treasurehunt/ui/login/LogInFragment.kt
+++ b/app/src/main/java/com/treasurehunt/ui/login/LogInFragment.kt
@@ -4,7 +4,6 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
@@ -18,8 +17,8 @@ import com.navercorp.nid.profile.NidProfileCallback
 import com.navercorp.nid.profile.data.NidProfileResponse
 import com.treasurehunt.BuildConfig
 import com.treasurehunt.R
-import com.treasurehunt.ui.model.NaverUser
 import com.treasurehunt.databinding.FragmentLoginBinding
+import com.treasurehunt.ui.model.NaverUser
 import com.treasurehunt.util.showSnackbar
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
@@ -29,11 +28,11 @@ private const val NAVER_LOGIN_CLIENT_SECRET = BuildConfig.NAVER_LOGIN_CLIENT_SEC
 private const val APP_NAME = BuildConfig.APP_NAME
 
 @AndroidEntryPoint
-class LogInFragment : Fragment() {
+class LogInFragment : PreloadFragment() {
 
     private var _binding: FragmentLoginBinding? = null
     private val binding get() = _binding!!
-    private val viewModel: LoginViewModel by viewModels()
+    override val viewModel: LoginViewModel by viewModels()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -114,6 +113,7 @@ class LogInFragment : Fragment() {
                 if (task.isSuccessful) {
                     lifecycleScope.launch {
                         viewModel.initLocalData()
+                        preloadProfileImage(Firebase.auth.currentUser)
                         findNavController().navigate(R.id.action_logInFragment_to_homeFragment)
                     }
                 } else {
@@ -128,6 +128,7 @@ class LogInFragment : Fragment() {
                 if (task.isSuccessful) {
                     lifecycleScope.launch {
                         viewModel.insertNaverUser(naverUser)
+                        preloadProfileImage(Firebase.auth.currentUser)
                         findNavController().navigate(R.id.action_logInFragment_to_homeFragment)
                     }
                 } else {

--- a/app/src/main/java/com/treasurehunt/ui/login/LoginViewModel.kt
+++ b/app/src/main/java/com/treasurehunt/ui/login/LoginViewModel.kt
@@ -2,9 +2,8 @@ package com.treasurehunt.ui.login
 
 import android.net.Uri
 import androidx.lifecycle.ViewModel
-import com.google.firebase.auth.ktx.auth
+import com.google.firebase.auth.FirebaseUser
 import com.google.firebase.auth.userProfileChangeRequest
-import com.google.firebase.ktx.Firebase
 import com.treasurehunt.data.LogRepository
 import com.treasurehunt.data.PlaceRepository
 import com.treasurehunt.data.UserRepository
@@ -13,10 +12,7 @@ import com.treasurehunt.data.remote.model.toLogEntity
 import com.treasurehunt.data.remote.model.toPlaceEntity
 import com.treasurehunt.ui.model.NaverUser
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.delay
 import javax.inject.Inject
-
-const val USER_UPDATE_DELAY = 1000L
 
 @HiltViewModel
 class LoginViewModel @Inject constructor(
@@ -25,59 +21,56 @@ class LoginViewModel @Inject constructor(
     private val placeRepo: PlaceRepository
 ) : ViewModel() {
 
-    suspend fun insertNaverUser(naverUser: NaverUser) {
-        updateProfile(naverUser)
-        delay(USER_UPDATE_DELAY)
-        val currentUser = Firebase.auth.currentUser!!
-        val userDTO = UserDTO(
-            email = currentUser.email,
-            nickname = currentUser.displayName,
-            profileImage = currentUser.photoUrl?.toString()
+    suspend fun insertNaverUser(naverUser: NaverUser, currentUser: FirebaseUser) {
+        updateProfile(naverUser, currentUser)
+
+        val user = UserDTO(
+            email = naverUser.email,
+            nickname = naverUser.nickname,
+            profileImage = naverUser.profileImage
         )
-        userRepo.insert(currentUser.uid, userDTO)
+        userRepo.insert(currentUser.uid, user)
     }
 
-    suspend fun insertGuestUser() {
-        val currentUser = Firebase.auth.currentUser!!
-        val userDTO = UserDTO(
+    suspend fun insertGuestUser(uid: String) {
+        val user = UserDTO(
             email = ""
         )
-        userRepo.insert(currentUser.uid, userDTO)
+        userRepo.insert(uid, user)
     }
 
-    private fun updateProfile(naverUser: NaverUser) {
+    private fun updateProfile(naverUser: NaverUser, currentUser: FirebaseUser) {
         val profileUpdate = userProfileChangeRequest {
             displayName = naverUser.nickname
             photoUri = Uri.parse(naverUser.profileImage)
         }
-        Firebase.auth.currentUser!!.updateProfile(profileUpdate)
+        currentUser.updateProfile(profileUpdate)
     }
 
-    suspend fun initLocalData() {
-        val curUserUid = Firebase.auth.currentUser!!.uid
-        val userDTO = userRepo.getRemoteUserById(curUserUid)
-        initLocalLogs(userDTO)
-        initLocalPlaces(userDTO)
+    suspend fun initLocalData(uid: String) {
+        val user = userRepo.getRemoteUserById(uid)
+        initLocalLogs(user)
+        initLocalPlaces(user)
     }
 
-    private suspend fun initLocalLogs(userDTO: UserDTO) {
+    private suspend fun initLocalLogs(user: UserDTO) {
         logRepo.deleteAllLocalLogs()
-        userDTO.remoteLogIds.filterValues { it }.map {
+        user.remoteLogIds.filterValues { it }.map {
             val log = logRepo.getRemoteLogById(it.key)
             logRepo.insert(log.toLogEntity(it.key))
         }
     }
 
-    private suspend fun initLocalPlaces(userDTO: UserDTO) {
+    private suspend fun initLocalPlaces(user: UserDTO) {
         placeRepo.deleteAllLocalPlaces()
-        (userDTO.remoteVisitIds + userDTO.remotePlanIds).filterValues { it }.map {
+        (user.remoteVisitIds + user.remotePlanIds).filterValues { it }.map {
             val place = placeRepo.getRemotePlaceById(it.key)
             placeRepo.insert(place.toPlaceEntity(it.key))
         }
     }
 
     suspend fun getProfileImageStorageUrl(uid: String): String? {
-        val userDTO = userRepo.getRemoteUserById(uid)
-        return userDTO.profileImage
+        val user = userRepo.getRemoteUserById(uid)
+        return user.profileImage
     }
 }

--- a/app/src/main/java/com/treasurehunt/ui/login/LoginViewModel.kt
+++ b/app/src/main/java/com/treasurehunt/ui/login/LoginViewModel.kt
@@ -7,11 +7,11 @@ import com.google.firebase.auth.userProfileChangeRequest
 import com.google.firebase.ktx.Firebase
 import com.treasurehunt.data.LogRepository
 import com.treasurehunt.data.PlaceRepository
-import com.treasurehunt.ui.model.NaverUser
 import com.treasurehunt.data.UserRepository
 import com.treasurehunt.data.remote.model.UserDTO
 import com.treasurehunt.data.remote.model.toLogEntity
 import com.treasurehunt.data.remote.model.toPlaceEntity
+import com.treasurehunt.ui.model.NaverUser
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.delay
 import javax.inject.Inject
@@ -74,5 +74,10 @@ class LoginViewModel @Inject constructor(
             val place = placeRepo.getRemotePlaceById(it.key)
             placeRepo.insert(place.toPlaceEntity(it.key))
         }
+    }
+
+    suspend fun getProfileImageStorageUrl(uid: String): String? {
+        val userDTO = userRepo.getRemoteUserById(uid)
+        return userDTO.profileImage
     }
 }

--- a/app/src/main/java/com/treasurehunt/ui/login/PreloadFragment.kt
+++ b/app/src/main/java/com/treasurehunt/ui/login/PreloadFragment.kt
@@ -1,0 +1,19 @@
+package com.treasurehunt.ui.login
+
+import androidx.fragment.app.Fragment
+import com.bumptech.glide.Glide
+import com.google.firebase.auth.FirebaseUser
+
+abstract class PreloadFragment : Fragment() {
+
+    protected abstract val viewModel: LoginViewModel
+
+    protected suspend fun preloadProfileImage(currentUser: FirebaseUser?) {
+        if (currentUser == null) return
+
+        val profileImageStorageUrl = viewModel.getProfileImageStorageUrl(currentUser.uid) ?: return
+        Glide.with(requireContext())
+            .load(profileImageStorageUrl)
+            .preload()
+    }
+}

--- a/app/src/main/java/com/treasurehunt/ui/login/SplashFragment.kt
+++ b/app/src/main/java/com/treasurehunt/ui/login/SplashFragment.kt
@@ -15,6 +15,8 @@ import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
+private const val SPLASH_ANIMATION_DURATION = 2000L
+
 @AndroidEntryPoint
 class SplashFragment : PreloadFragment() {
 
@@ -44,21 +46,20 @@ class SplashFragment : PreloadFragment() {
         binding.animationView.playAnimation()
 
         lifecycleScope.launch {
-            delay(2000)
+            delay(SPLASH_ANIMATION_DURATION)
             handleAutoLogin()
         }
     }
 
     private fun handleAutoLogin() {
-        val currentUser = Firebase.auth.currentUser
-        if (currentUser == null) {
+        val currentUser = Firebase.auth.currentUser ?: return kotlin.run {
             findNavController().navigate(R.id.action_splashFragment_to_logInFragment)
-        } else {
-            viewLifecycleOwner.lifecycleScope.launch {
-                viewModel.initLocalData()
-                preloadProfileImage(currentUser)
-                findNavController().navigate(R.id.action_splashFragment_to_homeFragment)
-            }
+        }
+
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewModel.initLocalData(currentUser.uid)
+            preloadProfileImage(currentUser)
+            findNavController().navigate(R.id.action_splashFragment_to_homeFragment)
         }
     }
 }

--- a/app/src/main/java/com/treasurehunt/ui/login/SplashFragment.kt
+++ b/app/src/main/java/com/treasurehunt/ui/login/SplashFragment.kt
@@ -8,6 +8,8 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
+import com.bumptech.glide.Glide
+import com.google.firebase.auth.FirebaseUser
 import com.google.firebase.auth.ktx.auth
 import com.google.firebase.ktx.Firebase
 import com.treasurehunt.R
@@ -26,8 +28,7 @@ class SplashFragment : Fragment() {
 
 
     override fun onCreateView(
-        inflater: LayoutInflater, container: ViewGroup?,
-        savedInstanceState: Bundle?
+        inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?
     ): View {
         _binding = FragmentSplashBinding.inflate(inflater, container, false)
         return binding.root
@@ -62,13 +63,22 @@ class SplashFragment : Fragment() {
     }
 
     private fun handleAutoLogin() {
-        if (Firebase.auth.currentUser == null) {
+        val currentUser = Firebase.auth.currentUser
+        if (currentUser == null) {
             findNavController().navigate(R.id.action_splashFragment_to_logInFragment)
         } else {
             lifecycleScope.launch {
                 viewModel.initLocalData()
+                preloadProfileImage(currentUser)
                 findNavController().navigate(R.id.action_splashFragment_to_homeFragment)
             }
         }
+    }
+
+    private suspend fun preloadProfileImage(currentUser: FirebaseUser) {
+        val profileImageStorageUrl = viewModel.getProfileImageStorageUrl(currentUser.uid) ?: return
+        Glide.with(requireContext())
+            .load(profileImageStorageUrl)
+            .preload()
     }
 }

--- a/app/src/main/java/com/treasurehunt/ui/login/SplashFragment.kt
+++ b/app/src/main/java/com/treasurehunt/ui/login/SplashFragment.kt
@@ -4,12 +4,9 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
-import com.bumptech.glide.Glide
-import com.google.firebase.auth.FirebaseUser
 import com.google.firebase.auth.ktx.auth
 import com.google.firebase.ktx.Firebase
 import com.treasurehunt.R
@@ -18,14 +15,12 @@ import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
-
 @AndroidEntryPoint
-class SplashFragment : Fragment() {
+class SplashFragment : PreloadFragment() {
+
     private var _binding: FragmentSplashBinding? = null
     private val binding get() = _binding!!
-    private var isInitialized = false
-    private val viewModel: LoginViewModel by viewModels()
-
+    override val viewModel: LoginViewModel by viewModels()
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?
@@ -34,16 +29,9 @@ class SplashFragment : Fragment() {
         return binding.root
     }
 
-    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        super.onViewCreated(view, savedInstanceState)
-        initSplashScreen()
-    }
-
     override fun onResume() {
         super.onResume()
-        if (isInitialized) {
-            handleAutoLogin()
-        }
+        initSplashScreen()
     }
 
     override fun onDestroyView() {
@@ -57,7 +45,6 @@ class SplashFragment : Fragment() {
 
         lifecycleScope.launch {
             delay(2000)
-            isInitialized = true
             handleAutoLogin()
         }
     }
@@ -67,18 +54,11 @@ class SplashFragment : Fragment() {
         if (currentUser == null) {
             findNavController().navigate(R.id.action_splashFragment_to_logInFragment)
         } else {
-            lifecycleScope.launch {
+            viewLifecycleOwner.lifecycleScope.launch {
                 viewModel.initLocalData()
                 preloadProfileImage(currentUser)
                 findNavController().navigate(R.id.action_splashFragment_to_homeFragment)
             }
         }
-    }
-
-    private suspend fun preloadProfileImage(currentUser: FirebaseUser) {
-        val profileImageStorageUrl = viewModel.getProfileImageStorageUrl(currentUser.uid) ?: return
-        Glide.with(requireContext())
-            .load(profileImageStorageUrl)
-            .preload()
     }
 }

--- a/app/src/main/java/com/treasurehunt/ui/model/ProfileUiState.kt
+++ b/app/src/main/java/com/treasurehunt/ui/model/ProfileUiState.kt
@@ -1,0 +1,10 @@
+package com.treasurehunt.ui.model
+
+import com.treasurehunt.data.remote.model.UserDTO
+
+data class ProfileUiState(
+    val uid: String? = null,
+    val user: UserDTO? = null,
+    val imageContentUri: String? = null,
+    val imageStorageUrl: String? = null
+)

--- a/app/src/main/java/com/treasurehunt/ui/profile/FriendViewModel.kt
+++ b/app/src/main/java/com/treasurehunt/ui/profile/FriendViewModel.kt
@@ -47,7 +47,6 @@ class FriendViewModel @Inject constructor(
 
     private val _uiState: MutableStateFlow<FriendUiState> = MutableStateFlow(FriendUiState(false))
     val uiState: StateFlow<FriendUiState> = _uiState.asStateFlow()
-    private val db = FirebaseDatabase.getInstance(BASE_URL)
     private val friendIds: Flow<List<String>> = getFriendIdsFlow()
 
     init {
@@ -58,6 +57,7 @@ class FriendViewModel @Inject constructor(
     }
 
     private fun getFriendIdsFlow(): Flow<List<String>> = callbackFlow {
+        val db = FirebaseDatabase.getInstance(BASE_URL)
         val uid = Firebase.auth.currentUser!!.uid
         val friendsRef =
             db.reference.child(REMOTE_DATABASE_USERS).child(uid).child(pathStringFriends)

--- a/app/src/main/java/com/treasurehunt/ui/profile/ProfileFragment.kt
+++ b/app/src/main/java/com/treasurehunt/ui/profile/ProfileFragment.kt
@@ -124,6 +124,16 @@ class ProfileFragment : Fragment() {
         binding.etNickname.setText(binding.tvNickname.text)
     }
 
+    private fun setEditProfileImageButton() {
+        binding.ibEditProfileImage.setOnClickListener {
+            requestAlbumAccessPermission()
+        }
+
+        binding.ivProfileImage.setOnClickListener {
+            requestAlbumAccessPermission()
+        }
+    }
+
     private fun setCancelButton() {
         binding.btnCancel.setOnClickListener {
             hideEditView()

--- a/app/src/main/java/com/treasurehunt/ui/profile/ProfileFragment.kt
+++ b/app/src/main/java/com/treasurehunt/ui/profile/ProfileFragment.kt
@@ -55,6 +55,7 @@ class ProfileFragment : Fragment() {
         syncProfile()
         setEditButton()
         setEditProfileImageButton()
+        setEditProfileImage()
         setCancelButton()
         setCompleteButton()
         initTabLayout()
@@ -144,7 +145,9 @@ class ProfileFragment : Fragment() {
         binding.ibEditProfileImage.setOnClickListener {
             requestAlbumAccessPermission()
         }
+    }
 
+    private fun setEditProfileImage() {
         binding.ivProfileImage.setOnClickListener {
             requestAlbumAccessPermission()
         }
@@ -153,7 +156,7 @@ class ProfileFragment : Fragment() {
     private fun setCancelButton() {
         binding.btnCancel.setOnClickListener {
             hideEditView()
-            updateProfile(viewModel.uiState.value.user ?: return@setOnClickListener)
+            updateProfile(viewModel.uiState.value.user)
         }
     }
 
@@ -164,10 +167,19 @@ class ProfileFragment : Fragment() {
 
     private fun setCompleteButton() {
         binding.btnComplete.setOnClickListener {
-            viewLifecycleOwner.lifecycleScope.launch {
-                viewModel.saveProfile(nickname = binding.etNickname.text.toString())
-            }
+            presetNickname()
+            saveProfile()
             hideEditView()
+        }
+    }
+
+    private fun presetNickname() {
+        binding.tvNickname.text = binding.etNickname.text
+    }
+
+    private fun saveProfile() {
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewModel.saveProfile(nickname = binding.etNickname.text.toString())
         }
     }
 

--- a/app/src/main/java/com/treasurehunt/ui/profile/ProfileViewModel.kt
+++ b/app/src/main/java/com/treasurehunt/ui/profile/ProfileViewModel.kt
@@ -43,6 +43,7 @@ private const val BASE_URL = BuildConfig.BASE_URL
 private val pathEmail = UserDTO::email.name
 private val pathNickname = UserDTO::nickname.name
 private val pathProfileImage = UserDTO::profileImage.name
+private const val IMAGE_FILENAME_PREFIX = "$STORAGE_LOCATION_PROFILE_IMAGE/"
 
 @HiltViewModel
 class ProfileViewModel @Inject constructor(
@@ -133,11 +134,13 @@ class ProfileViewModel @Inject constructor(
     }
 
     suspend fun saveProfile(nickname: String) {
+        val uid = _uiState.value.uid ?: return
         val user = _uiState.value.user ?: return
         val imageContentUri = _uiState.value.imageContentUri
 
         imageContentUri?.let {
             uploadProfileImage(it.toUri())
+            deleteReplacedProfileImage(uid, user)
         }
 
         updateUser(
@@ -161,6 +164,13 @@ class ProfileViewModel @Inject constructor(
         } else {
             // TODO: handle fail
         }
+    }
+
+    private fun deleteReplacedProfileImage(uid: String, user: UserDTO) {
+        val imagesStorageRef =
+            Firebase.storage.reference.child(uid).child(STORAGE_LOCATION_PROFILE_IMAGE)
+        val imageFilename = user.profileImage?.substringAfter(IMAGE_FILENAME_PREFIX) ?: return
+        imagesStorageRef.child(imageFilename).delete()
     }
 
     private fun addImageStorageUrl(imageStorageUrl: String) {

--- a/app/src/main/java/com/treasurehunt/ui/profile/ProfileViewModel.kt
+++ b/app/src/main/java/com/treasurehunt/ui/profile/ProfileViewModel.kt
@@ -1,59 +1,131 @@
 package com.treasurehunt.ui.profile
 
 import android.content.Intent
+import android.net.Uri
 import android.provider.MediaStore
-import androidx.lifecycle.LiveData
-import androidx.lifecycle.MutableLiveData
+import androidx.core.net.toUri
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.google.firebase.Firebase
 import com.google.firebase.auth.auth
+import com.google.firebase.storage.storage
 import com.treasurehunt.data.UserRepository
 import com.treasurehunt.data.remote.model.UserDTO
+import com.treasurehunt.ui.model.ProfileUiState
+import com.treasurehunt.util.FILENAME_EXTENSION_PNG
 import com.treasurehunt.util.MIME_TYPE_IMAGE
+import com.treasurehunt.util.STORAGE_LOCATION_PROFILE_IMAGE
+import com.treasurehunt.util.extractDigits
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.tasks.await
 import javax.inject.Inject
 
 @HiltViewModel
 class ProfileViewModel @Inject constructor(
-    private val userRepository: UserRepository
+    private val userRepo: UserRepository
 ) : ViewModel() {
 
-    private val _userData: MutableLiveData<UserDTO> = MutableLiveData<UserDTO>()
-    val userData: LiveData<UserDTO> = _userData
-    private val _imageUri: MutableLiveData<String> = MutableLiveData<String>()
-    val imageUri: LiveData<String> = _imageUri
-    private val _profileUri: MutableLiveData<String> = MutableLiveData<String>()
-    val profileUri: LiveData<String> = _profileUri
+    private val _uiState: MutableStateFlow<ProfileUiState> = MutableStateFlow(ProfileUiState())
+    val uiState: StateFlow<ProfileUiState> = _uiState.asStateFlow()
 
-    fun setProfileUri(profileUri: String) {
-        _profileUri.value = profileUri
-    }
-
-    fun getImage() = Intent(Intent.ACTION_PICK, MediaStore.Images.Media.EXTERNAL_CONTENT_URI).apply {
-        type = MIME_TYPE_IMAGE
-    }
-
-    fun addImage(image: String) {
-        _imageUri.value = image
-    }
-
-    fun getUserData() {
-        val uid = Firebase.auth.currentUser!!.uid
+    init {
         viewModelScope.launch {
-            _userData.value = userRepository.getRemoteUserById(uid)
+            initUid()
+            syncUid()
+            syncUser()
         }
     }
 
-    fun updateUserData(userDTO: UserDTO) {
-        viewModelScope.launch {
-            userRepository.update(
-                Firebase.auth.currentUser!!.uid,
-                userDTO
+    private fun initUid() {
+        _uiState.update {
+            it.copy(uid = Firebase.auth.currentUser?.uid)
+        }
+    }
+
+    private fun syncUid() {
+        Firebase.auth.addAuthStateListener { auth ->
+            _uiState.update {
+                it.copy(uid = auth.currentUser?.uid)
+            }
+        }
+    }
+
+    private suspend fun syncUser() {
+        val uid = _uiState.value.uid ?: return
+        _uiState.update {
+            it.copy(user = userRepo.getRemoteUserById(uid))
+        }
+    }
+
+    fun getImagePick() =
+        Intent(Intent.ACTION_PICK, MediaStore.Images.Media.EXTERNAL_CONTENT_URI).apply {
+            type = MIME_TYPE_IMAGE
+        }
+
+    fun addImageContentUri(contentUri: String) {
+        _uiState.update {
+            it.copy(imageContentUri = contentUri)
+        }
+    }
+
+    suspend fun saveProfile(nickname: String) {
+        val user = _uiState.value.user ?: return
+        val imageContentUri = _uiState.value.imageContentUri
+
+        imageContentUri?.let {
+            uploadProfileImage(it.toUri())
+        }
+
+        updateUser(
+            user.copy(
+                nickname = nickname,
+                profileImage = _uiState.value.imageStorageUrl
+            )
+        )
+
+        syncUser() // not needed if syncUser operates on callbackflow
+    }
+
+    private suspend fun uploadProfileImage(uri: Uri) {
+        val uid = _uiState.value.uid ?: return
+        val filename = uri.toString().extractDigits()
+        val profileImageStorageRef =
+            Firebase.storage.reference.child(uid).child(STORAGE_LOCATION_PROFILE_IMAGE)
+                .child("$filename$FILENAME_EXTENSION_PNG")
+        val uploadTask = profileImageStorageRef.putFile(uri)
+        uploadTask.await()
+        if (uploadTask.isSuccessful) {
+            addImageStorageUrl(uploadTask.snapshot.storage.toString())
+        } else {
+            // TODO: handle fail
+        }
+    }
+
+    private fun addImageStorageUrl(imageStorageUrl: String) {
+        _uiState.update {
+            it.copy(
+                imageContentUri = null,
+                imageStorageUrl = imageStorageUrl
             )
         }
-        _userData.value = userDTO
+    }
+
+    private suspend fun updateUser(user: UserDTO) {
+        val uid = _uiState.value.uid ?: return
+
+        userRepo.update(
+            uid,
+            user
+        )
+
+        _uiState.update {
+            it.copy(user = user)
+        }
     }
 }
 

--- a/app/src/main/java/com/treasurehunt/ui/profile/ProfileViewModel.kt
+++ b/app/src/main/java/com/treasurehunt/ui/profile/ProfileViewModel.kt
@@ -6,24 +6,43 @@ import android.provider.MediaStore
 import androidx.core.net.toUri
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.google.firebase.Firebase
-import com.google.firebase.auth.auth
-import com.google.firebase.storage.storage
+import com.google.firebase.FirebaseException
+import com.google.firebase.database.DataSnapshot
+import com.google.firebase.database.DatabaseError
+import com.google.firebase.database.FirebaseDatabase
+import com.google.firebase.database.ValueEventListener
+import com.google.firebase.ktx.Firebase
+import com.google.firebase.storage.ktx.storage
+import com.treasurehunt.BuildConfig
 import com.treasurehunt.data.UserRepository
+import com.treasurehunt.data.remote.REMOTE_DATABASE_USERS
 import com.treasurehunt.data.remote.model.UserDTO
 import com.treasurehunt.ui.model.ProfileUiState
+import com.treasurehunt.util.COMPILATION_WARNING_UNCHECKED_CAST
 import com.treasurehunt.util.FILENAME_EXTENSION_PNG
 import com.treasurehunt.util.MIME_TYPE_IMAGE
 import com.treasurehunt.util.STORAGE_LOCATION_PROFILE_IMAGE
 import com.treasurehunt.util.extractDigits
+import com.treasurehunt.util.getUidCallbackFlow
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.channels.trySendBlocking
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.transform
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.tasks.await
 import javax.inject.Inject
+
+private const val BASE_URL = BuildConfig.BASE_URL
+private val pathEmail = UserDTO::email.name
+private val pathNickname = UserDTO::nickname.name
+private val pathProfileImage = UserDTO::profileImage.name
 
 @HiltViewModel
 class ProfileViewModel @Inject constructor(
@@ -32,33 +51,73 @@ class ProfileViewModel @Inject constructor(
 
     private val _uiState: MutableStateFlow<ProfileUiState> = MutableStateFlow(ProfileUiState())
     val uiState: StateFlow<ProfileUiState> = _uiState.asStateFlow()
+    private val uid: Flow<String?> = getUidCallbackFlow()
+    private val user: Flow<UserDTO?> = uid.convertToUserFlow()
 
     init {
-        viewModelScope.launch {
-            initUid()
-            syncUid()
-            syncUser()
+        initUid()
+        initUser()
+    }
+
+    private fun Flow<String?>.convertToUserFlow() = transform { uid ->
+        if (uid == null) {
+            emit(null)
+        } else {
+            emitAll(getRemoteUserFlow(uid))
         }
+    }
+
+    private fun getRemoteUserFlow(uid: String): Flow<UserDTO?> = callbackFlow {
+        val db = FirebaseDatabase.getInstance(BASE_URL)
+        val userRef = db.reference.child(REMOTE_DATABASE_USERS).child(uid)
+        val callback = object : ValueEventListener {
+            @Suppress(COMPILATION_WARNING_UNCHECKED_CAST)
+            override fun onDataChange(snapshot: DataSnapshot) {
+                snapshot.run {
+                    val email = child(pathEmail).value as? String?
+                    val nickname = child(pathNickname).value as? String?
+                    val profileImage = child(pathProfileImage).value as? String?
+                    trySendBlocking(
+                        UserDTO(
+                            email = email,
+                            nickname = nickname,
+                            profileImage = profileImage,
+                        )
+                    )
+                }
+            }
+
+            override fun onCancelled(error: DatabaseError) {
+            }
+        }
+
+        try {
+            userRef.addValueEventListener(callback)
+        } catch (e: FirebaseException) {
+            trySendBlocking(null)
+            channel.close()
+        }
+
+        awaitClose { userRef.removeEventListener(callback) }
     }
 
     private fun initUid() {
-        _uiState.update {
-            it.copy(uid = Firebase.auth.currentUser?.uid)
-        }
-    }
-
-    private fun syncUid() {
-        Firebase.auth.addAuthStateListener { auth ->
-            _uiState.update {
-                it.copy(uid = auth.currentUser?.uid)
+        viewModelScope.launch {
+            uid.collect { uid ->
+                _uiState.update {
+                    it.copy(uid = uid)
+                }
             }
         }
     }
 
-    private suspend fun syncUser() {
-        val uid = _uiState.value.uid ?: return
-        _uiState.update {
-            it.copy(user = userRepo.getRemoteUserById(uid))
+    private fun initUser() {
+        viewModelScope.launch {
+            user.collect { user ->
+                _uiState.update {
+                    it.copy(user = user)
+                }
+            }
         }
     }
 
@@ -87,8 +146,6 @@ class ProfileViewModel @Inject constructor(
                 profileImage = _uiState.value.imageStorageUrl
             )
         )
-
-        syncUser() // not needed if syncUser operates on callbackflow
     }
 
     private suspend fun uploadProfileImage(uri: Uri) {
@@ -128,4 +185,3 @@ class ProfileViewModel @Inject constructor(
         }
     }
 }
-

--- a/app/src/main/java/com/treasurehunt/ui/savelog/SaveLogFragment.kt
+++ b/app/src/main/java/com/treasurehunt/ui/savelog/SaveLogFragment.kt
@@ -202,12 +202,17 @@ class SaveLogFragment : Fragment(), OnMapReadyCallback {
 
     private fun setPickImageButton() {
         binding.ibPickImage.setOnClickListener {
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-                requestPermissionLauncher.launch(android.Manifest.permission.READ_MEDIA_IMAGES)
-            } else {
-                requestPermissionLauncher.launch(android.Manifest.permission.READ_EXTERNAL_STORAGE)
-            }
+            requestAlbumAccessPermission()
         }
+    }
+
+    private fun requestAlbumAccessPermission() {
+        val permissionId = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            android.Manifest.permission.READ_MEDIA_IMAGES
+        } else {
+            android.Manifest.permission.READ_EXTERNAL_STORAGE
+        }
+        requestPermissionLauncher.launch(permissionId)
     }
 
     private fun setSaveButton() {

--- a/app/src/main/java/com/treasurehunt/util/Functions.kt
+++ b/app/src/main/java/com/treasurehunt/util/Functions.kt
@@ -1,12 +1,37 @@
 package com.treasurehunt.util
 
 import android.os.Build
+import com.google.firebase.Firebase
+import com.google.firebase.FirebaseException
+import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.auth.auth
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.channels.trySendBlocking
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
 import java.time.LocalDateTime
 import java.time.ZoneId
 import java.util.Date
 
-fun getCurrentTime() = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+fun getCurrentTime(): Long = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
     LocalDateTime.now().atZone(ZoneId.systemDefault()).toInstant().toEpochMilli()
 } else {
     Date().time
+}
+
+internal fun getUidCallbackFlow(): Flow<String?> = callbackFlow {
+    val callback = FirebaseAuth.AuthStateListener { auth ->
+        trySendBlocking(auth.currentUser?.uid)
+    }
+
+    try {
+        Firebase.auth.addAuthStateListener(callback)
+    } catch (e: FirebaseException) {
+        trySendBlocking(null)
+        channel.close()
+    }
+
+    awaitClose {
+        Firebase.auth.removeAuthStateListener(callback)
+    }
 }

--- a/app/src/main/res/drawable/ic_circle_white.xml
+++ b/app/src/main/res/drawable/ic_circle_white.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="oval">
+    <solid android:color="@color/white" />
+</shape>

--- a/app/src/main/res/layout/fragment_profile.xml
+++ b/app/src/main/res/layout/fragment_profile.xml
@@ -42,7 +42,7 @@
             app:shapeAppearance="@style/ProfileImage" />
 
         <ImageButton
-            android:id="@+id/ib_camera"
+            android:id="@+id/ib_edit_profile_image"
             android:layout_width="20dp"
             android:layout_height="20dp"
             android:layout_marginTop="8dp"
@@ -72,6 +72,7 @@
             android:layout_marginStart="16dp"
             android:layout_marginTop="16dp"
             android:background="@drawable/button_record"
+            android:maxLength="10"
             android:paddingHorizontal="20dp"
             android:visibility="gone"
             app:layout_constraintStart_toEndOf="@id/iv_profile_image"
@@ -100,25 +101,34 @@
             app:layout_constraintEnd_toEndOf="@+id/view_container"
             app:layout_constraintTop_toTopOf="@+id/view_container" />
 
-        <TextView
-            android:id="@+id/tv_cancel"
+        <Button
+            android:id="@+id/btn_cancel"
             style="@style/Font.ProfileAccount"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginEnd="16dp"
+            android:background="@android:color/transparent"
+            android:minWidth="0dp"
+            android:minHeight="0dp"
+            android:paddingHorizontal="24dp"
+            android:paddingVertical="0dp"
             android:text="@string/profile_tv_cancel"
             android:visibility="gone"
-            app:layout_constraintEnd_toStartOf="@+id/tv_completed"
-            app:layout_constraintTop_toTopOf="@+id/tv_completed" />
+            app:layout_constraintEnd_toStartOf="@+id/btn_complete"
+            app:layout_constraintTop_toTopOf="@+id/btn_complete" />
 
-        <TextView
-            android:id="@+id/tv_completed"
+        <Button
+            android:id="@+id/btn_complete"
             style="@style/Font.ProfileAccount"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginTop="16dp"
-            android:layout_marginEnd="16dp"
-            android:text="@string/profile_tv_completed"
+            android:layout_marginEnd="24dp"
+            android:background="@android:color/transparent"
+            android:minWidth="0dp"
+            android:minHeight="0dp"
+            android:padding="0dp"
+            android:paddingHorizontal="24dp"
+            android:paddingVertical="0dp"
+            android:text="@string/profile_tv_complete"
             android:textColor="@color/blue"
             android:visibility="gone"
             app:layout_constraintEnd_toEndOf="@+id/view_container"
@@ -136,7 +146,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:visibility="gone"
-            app:constraint_referenced_ids="tv_cancel,tv_completed,ib_camera,et_nickname" />
+            app:constraint_referenced_ids="btn_cancel,btn_complete,ib_edit_profile_image,et_nickname" />
 
         <com.google.android.material.tabs.TabLayout
             android:id="@+id/tl_notification"

--- a/app/src/main/res/layout/fragment_profile.xml
+++ b/app/src/main/res/layout/fragment_profile.xml
@@ -43,11 +43,14 @@
 
         <ImageButton
             android:id="@+id/ib_edit_profile_image"
-            android:layout_width="20dp"
-            android:layout_height="20dp"
+            android:layout_width="24dp"
+            android:layout_height="24dp"
             android:layout_marginTop="8dp"
             android:layout_marginEnd="8dp"
-            android:background="@android:color/transparent"
+            android:background="@drawable/ic_circle_white"
+            android:paddingHorizontal="2dp"
+            android:paddingTop="1dp"
+            android:scaleType="fitCenter"
             android:src="@drawable/ic_camera"
             android:visibility="gone"
             app:layout_constraintEnd_toEndOf="@+id/iv_profile_image"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -51,11 +51,12 @@
     <string name="profile_tv_nickname">닉네임</string>
     <string name="profile_tv_account">abc@naver.com</string>
     <string name="profile_tv_cancel">취소</string>
-    <string name="profile_tv_completed">완료</string>
+    <string name="profile_tv_complete">완료</string>
     <string name="profile_tl_friend">친구</string>
     <string name="profile_tl_comment">댓글</string>
     <string name="profile_tl_tag">태그</string>
     <string name="profile_check_url">https://</string>
+    <string name="profile_guest">비회원</string>
 
     <!-- 프로필 화면 - 친구 -->
     <string name="profile_friend_tiet_search_friend_hint">이메일로 친구를 검색해 보세요</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -19,9 +19,8 @@
     <string name="login_naver">네이버로 계속하기</string>
     <string name="login_non_member">비회원으로 로그인</string>
     <string name="login_treasure_hunt">보물찾기</string>
-    <string name="login_naver_login_error">네이버 로그인 실패. 잠시 후 다시 시도해 주세요.</string>
-    <string name="login_create_account_error">회원가입 실패. 잠시 후 다시 시도해 주세요.</string>
-    <string name="login_guest_login_error">비회원 로그인 실패. 잠시 후 다시 시도해 주세요.</string>
+    <string name="login_naver_login_error">네이버로 계속하기 실패. 잠시 후 다시 시도해 주세요.</string>
+    <string name="login_guest_login_error">비회원으로 로그인 실패. 잠시 후 다시 시도해 주세요.</string>
 
     <!-- 기록 저장 화면 -->
     <string name="savelog_tv_title">내 추억</string>


### PR DESCRIPTION
커밋 원래 3개 정도로 구분해서 했는데, cherry-pick 하다가 작업 이력 날라갈 뻔한 거 복구하느라 1개로 퉁치게 되었습니다
최근에 다른 리팩토링 하다가 프로필 화면 프래그먼트에서 비즈니스 로직 처리하는 거 봐서 그걸 뷰모델로 이전하게 되었습니다
추가적으로 뷰모델의 라이브데이터 프로퍼티들을 하나의 uiState 스테이트플로우로 통합시켰습니다
이외에 추가사항
- 프로필 상자 안의 닉네임 textedit 최대입력자수 10으로 제한 (기존에는 제한 없었고 길게 쓰면 뷰가 이상해졌습니다)
- 프로필 상자 안의 편집버튼 누르는 경우 가시화되는 취소, 완료 버튼을 textview -> button으로 뷰타입 변경 (텍스트뷰로 돼있어서 실제로 xml에서 해당뷰를 찾기 힘들었고, 강사님이 버튼 역할 하는 뷰를 TextView로 하는 걸 권장하지 않는다고 했습니다)
- 닉네입 미지정 비회원인 경우, 닉네임 칸에 "비회원"이라는 글 표시 (파이어베이스 키값이 사용자에게 보이는 게 이상합니다)

** 데이터 바인딩 적용 안 했는데, 언제 할지 안 할지 아직 모르겠습니다
** 주석 한두개 있는데, 언젠가 코드개선시 참고용으로 필요할 수도 있어서 놔뒀는데 지워도 됩니다
** 해당 브랜치와 무관하지만, 주석 생각난 김에 홈액티비티의 준수님 주석 삭제해서 커밋 포함시켰습니다

-- 피드백 반영 및 추가 수정 --
- LiveData 라이브러리 제거
- 프로필사진 편집버튼 하얀 동그라미 배경의 카메라 아이콘으로 변경 및 이미지뷰 전체에 클릭리스너 적용
- 스플래시 화면에서 사용자의 프로필 이미지 preload해 캐시에 저장 (이제 프로필 화면에서 캐시에서 불러옵니다 로딩 시간 살짝 더 빨라진 느낌)
- 프로필 뷰모델에서 uid 및 user를 콜백플로우로 구현해 관리 (파이어베이스 Auth의 uid 값이나 파이어베이스 DB에서 현재 User의 데이터 변경시 실시간 반영)
- 프로필 화면에서 uiState 플로우의 불필요한 collect를 생략해 프로필 이미지의 자연스러운 렌더링 구현
- 프로필 이미지 변경시 이전 이미지 파일을 스토리지에서 삭제

-- 추가 3/10 --
- 네이버 로그인시 프로필 이미지 preload 적용 및 스플래시 화면 UI 로직을 onResume 콜백으로 이전 (준수님이 스플래시 무한반복 오류 해결하신 로직을 간소화해봤습니다)
- 프로필 화면 닉네임 변경시 UI에 즉시 반영

-- 추가 3/12 -- (** 로그인 화면 관련 주의)
- 네이버 계정으로 사용자 추가시, delay 대신 네이버 계정 정보 활용 및 함수, 상수, 스트링 리팩토링
- 네이버로 계정 생성시 프로필 이미지를 스토리지에 추가 및 파이어베이스의 유저 프로필 업데이트하는 함수 제거

** 커밋 따로 분리 했어야 하는데, 실수했네요. 리팩토링 내용 중에 로그인 뷰모델에서 non null assertion (!!)이 많이 사용되고 있는 거 같아서 최소화했으니 참고 바랍니다!