### PR TITLE
[지도 장소 검색 화면] 홈 지도 화면 상단에 검색바 추가 및 검색 화면 UI 구현, 위치 오버레이 아이콘에 프로필 이미지 적용

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -33,6 +33,10 @@ android {
         )
         buildConfigField("String", "APP_NAME", getApiKey("APP_NAME"))
         buildConfigField("String", "BASE_URL", getApiKey("BASE_URL"))
+
+        buildConfigField("String", "X_NAVER_CLIENT_ID", getApiKey("X_NAVER_CLIENT_ID"))
+        buildConfigField("String", "X_NAVER_CLIENT_SECRET", getApiKey("X_NAVER_CLIENT_SECRET"))
+        buildConfigField("String", "NAVER_SEARCH_API_BASE_URL", getApiKey("NAVER_SEARCH_API_BASE_URL"))
     }
 
     buildTypes {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -24,8 +24,7 @@
             android:name="androidx.startup.InitializationProvider"
             android:authorities="com.treasurehunt.androidx-startup"
             android:exported="false"
-            tools:node="remove">
-        </provider>
+            tools:node="remove"></provider>
 
         <meta-data
             android:name="com.naver.maps.map.CLIENT_ID"

--- a/app/src/main/java/com/treasurehunt/data/MapPlaceSearchRepository.kt
+++ b/app/src/main/java/com/treasurehunt/data/MapPlaceSearchRepository.kt
@@ -1,0 +1,8 @@
+package com.treasurehunt.data
+
+import com.treasurehunt.data.remote.model.MapPlaceSearchResultDTO
+
+interface MapPlaceSearchRepository {
+
+    suspend fun getMapPlaceByKeyword(keyword: String): MapPlaceSearchResultDTO
+}

--- a/app/src/main/java/com/treasurehunt/data/MapPlaceSearchRepositoryImpl.kt
+++ b/app/src/main/java/com/treasurehunt/data/MapPlaceSearchRepositoryImpl.kt
@@ -1,0 +1,12 @@
+package com.treasurehunt.data
+
+import com.treasurehunt.data.remote.MapPlaceSearchService
+import javax.inject.Inject
+
+class MapPlaceSearchRepositoryImpl @Inject constructor(
+    private val mapPlaceSearchService: MapPlaceSearchService
+) : MapPlaceSearchRepository {
+
+    override suspend fun getMapPlaceByKeyword(keyword: String) =
+        mapPlaceSearchService.getMapPlaceByKeyword(keyword)
+}

--- a/app/src/main/java/com/treasurehunt/data/MapPlaceSearchRepositoryImpl.kt
+++ b/app/src/main/java/com/treasurehunt/data/MapPlaceSearchRepositoryImpl.kt
@@ -1,12 +1,18 @@
 package com.treasurehunt.data
 
 import com.treasurehunt.data.remote.MapPlaceSearchService
+import com.treasurehunt.data.remote.model.MapPlaceSearchResultDTO
 import javax.inject.Inject
 
 class MapPlaceSearchRepositoryImpl @Inject constructor(
     private val mapPlaceSearchService: MapPlaceSearchService
 ) : MapPlaceSearchRepository {
 
-    override suspend fun getMapPlaceByKeyword(keyword: String) =
-        mapPlaceSearchService.getMapPlaceByKeyword(keyword)
+    override suspend fun getMapPlaceByKeyword(keyword: String): MapPlaceSearchResultDTO {
+        return try {
+            mapPlaceSearchService.getMapPlaceByKeyword(keyword)
+        } catch(e: Exception) {
+            MapPlaceSearchResultDTO()
+        }
+    }
 }

--- a/app/src/main/java/com/treasurehunt/data/remote/MapPlaceSearchService.kt
+++ b/app/src/main/java/com/treasurehunt/data/remote/MapPlaceSearchService.kt
@@ -1,0 +1,16 @@
+package com.treasurehunt.data.remote
+
+import com.treasurehunt.data.remote.model.MapPlaceSearchResultDTO
+import retrofit2.http.GET
+import retrofit2.http.Query
+
+private const val LIMIT_MAX = 5
+
+interface MapPlaceSearchService {
+
+    @GET("local.json")
+    suspend fun getMapPlaceByKeyword(
+        @Query("query") keyword: String,
+        @Query("display") limit: Int = LIMIT_MAX
+    ): MapPlaceSearchResultDTO
+}

--- a/app/src/main/java/com/treasurehunt/data/remote/model/MapPlaceDTO.kt
+++ b/app/src/main/java/com/treasurehunt/data/remote/model/MapPlaceDTO.kt
@@ -7,11 +7,11 @@ import kotlinx.serialization.json.Json
 
 @Serializable
 data class MapPlaceSearchResultDTO(
-    val lastBuildDate: String,
-    val total: Long,
-    val start: Long,
-    val display: Long,
-    val items: List<MapPlaceDTO>
+    val lastBuildDate: String = "",
+    val total: Long = 0,
+    val start: Long = 0,
+    val display: Long = 0,
+    val items: List<MapPlaceDTO> = emptyList()
 )
 
 fun MapPlaceSearchResultDTO.toJsonString() = Json.encodeToString(this)

--- a/app/src/main/java/com/treasurehunt/data/remote/model/MapPlaceDTO.kt
+++ b/app/src/main/java/com/treasurehunt/data/remote/model/MapPlaceDTO.kt
@@ -1,0 +1,31 @@
+package com.treasurehunt.data.remote.model
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+
+@Serializable
+data class MapPlaceSearchResultDTO (
+    val lastBuildDate: String,
+    val total: Long,
+    val start: Long,
+    val display: Long,
+    val items: List<MapPlace>
+)
+
+fun MapPlaceSearchResultDTO.toJsonString() = Json.encodeToString(this)
+
+fun MapPlaceSearchResultDTO.fromJsonString(string: String) = Json.decodeFromString<MapPlaceSearchResultDTO>(string)
+
+@Serializable
+data class MapPlace (
+    val title: String,
+    val link: String,
+    val category: String,
+    val description: String,
+    val telephone: String,
+    val address: String,
+    val roadAddress: String,
+    val mapx: String,
+    val mapy: String
+)

--- a/app/src/main/java/com/treasurehunt/data/remote/model/MapPlaceDTO.kt
+++ b/app/src/main/java/com/treasurehunt/data/remote/model/MapPlaceDTO.kt
@@ -1,31 +1,37 @@
 package com.treasurehunt.data.remote.model
 
+import com.treasurehunt.ui.model.MapPlaceModel
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 
 @Serializable
-data class MapPlaceSearchResultDTO (
+data class MapPlaceSearchResultDTO(
     val lastBuildDate: String,
     val total: Long,
     val start: Long,
     val display: Long,
-    val items: List<MapPlace>
+    val items: List<MapPlaceDTO>
 )
 
 fun MapPlaceSearchResultDTO.toJsonString() = Json.encodeToString(this)
 
-fun MapPlaceSearchResultDTO.fromJsonString(string: String) = Json.decodeFromString<MapPlaceSearchResultDTO>(string)
+fun MapPlaceSearchResultDTO.fromJsonString(string: String) =
+    Json.decodeFromString<MapPlaceSearchResultDTO>(string)
 
 @Serializable
-data class MapPlace (
+data class MapPlaceDTO(
     val title: String,
-    val link: String,
-    val category: String,
-    val description: String,
-    val telephone: String,
-    val address: String,
-    val roadAddress: String,
-    val mapx: String,
-    val mapy: String
+    val link: String? = null,
+    val category: String? = null,
+    val description: String? = null,
+    val telephone: String? = null,
+    val address: String? = null,
+    val roadAddress: String? = null,
+    val mapx: String? = null,
+    val mapy: String? = null
+)
+
+fun MapPlaceDTO.toMapPlaceModel() = MapPlaceModel(
+    title, link, category, description, telephone, address, roadAddress, mapx, mapy
 )

--- a/app/src/main/java/com/treasurehunt/di/MapPlaceSearchModule.kt
+++ b/app/src/main/java/com/treasurehunt/di/MapPlaceSearchModule.kt
@@ -23,6 +23,7 @@ private const val HEADER_CLIENT_SECRET = "X-Naver-Client-Secret"
 private const val CLIENT_SECRET = BuildConfig.X_NAVER_CLIENT_SECRET
 private const val BASE_URL = BuildConfig.NAVER_SEARCH_API_BASE_URL
 private val contentType = "application/json".toMediaType()
+private const val CLIENT_QUALIFIER_MAP_PLACE_SEARCH = "MapPlaceSearch"
 
 @OptIn(ExperimentalSerializationApi::class)
 private val json = Json {
@@ -37,7 +38,7 @@ object MapPlaceSearchModule {
 
     @Singleton
     @Provides
-    @Named("MapPlaceSearch")
+    @Named(CLIENT_QUALIFIER_MAP_PLACE_SEARCH)
     fun provideClient(): OkHttpClient {
         return OkHttpClient.Builder()
             .addNetworkInterceptor { chain ->
@@ -51,8 +52,10 @@ object MapPlaceSearchModule {
 
     @Singleton
     @Provides
-    @Named("MapPlaceSearch")
-    fun provideRemoteBuilder(@Named("MapPlaceSearch") okHttpClient: OkHttpClient): Retrofit {
+    @Named(CLIENT_QUALIFIER_MAP_PLACE_SEARCH)
+    fun provideRemoteBuilder(
+        @Named(CLIENT_QUALIFIER_MAP_PLACE_SEARCH) okHttpClient: OkHttpClient
+    ): Retrofit {
         return Retrofit.Builder()
             .baseUrl(BASE_URL)
             .client(okHttpClient)
@@ -61,6 +64,8 @@ object MapPlaceSearchModule {
     }
 
     @Provides
-    fun provideMapSearchService(@Named("MapPlaceSearch") remoteBuilder: Retrofit): MapPlaceSearchService =
+    fun provideMapSearchService(
+        @Named(CLIENT_QUALIFIER_MAP_PLACE_SEARCH) remoteBuilder: Retrofit
+    ): MapPlaceSearchService =
         remoteBuilder.create(MapPlaceSearchService::class.java)
 }

--- a/app/src/main/java/com/treasurehunt/di/MapPlaceSearchModule.kt
+++ b/app/src/main/java/com/treasurehunt/di/MapPlaceSearchModule.kt
@@ -2,14 +2,12 @@ package com.treasurehunt.di
 
 import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFactory
 import com.treasurehunt.BuildConfig
-import com.treasurehunt.data.remote.ImageService
-import com.treasurehunt.data.remote.LogService
-import com.treasurehunt.data.remote.PlaceService
-import com.treasurehunt.data.remote.UserService
+import com.treasurehunt.data.remote.MapPlaceSearchService
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.json.Json
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
@@ -19,49 +17,50 @@ import javax.inject.Singleton
 
 private const val HEADER_USER_AGENT = "User-Agent"
 private const val APP_NAME = "TreasureHunt"
-private const val BASE_URL = BuildConfig.BASE_URL
+private const val HEADER_CLIENT_ID = "X-Naver-Client-Id"
+private const val CLIENT_ID = BuildConfig.X_NAVER_CLIENT_ID
+private const val HEADER_CLIENT_SECRET = "X-Naver-Client-Secret"
+private const val CLIENT_SECRET = BuildConfig.X_NAVER_CLIENT_SECRET
+private const val BASE_URL = BuildConfig.NAVER_SEARCH_API_BASE_URL
 private val contentType = "application/json".toMediaType()
+
+@OptIn(ExperimentalSerializationApi::class)
+private val json = Json {
+    ignoreUnknownKeys = true
+    coerceInputValues = true
+    explicitNulls = false
+}
 
 @Module
 @InstallIn(SingletonComponent::class)
-object NetworkModule {
+object MapPlaceSearchModule {
 
     @Singleton
     @Provides
-    @Named("RemoteDatabase")
+    @Named("MapPlaceSearch")
     fun provideClient(): OkHttpClient {
         return OkHttpClient.Builder()
             .addNetworkInterceptor { chain ->
                 val builder = chain.request().newBuilder()
                 builder.header(HEADER_USER_AGENT, APP_NAME)
+                    .header(HEADER_CLIENT_ID, CLIENT_ID)
+                    .header(HEADER_CLIENT_SECRET, CLIENT_SECRET)
                 return@addNetworkInterceptor chain.proceed(builder.build())
             }.build()
     }
 
     @Singleton
     @Provides
-    @Named("RemoteDatabase")
-    fun provideRemoteBuilder(@Named("RemoteDatabase") okHttpClient: OkHttpClient): Retrofit {
+    @Named("MapPlaceSearch")
+    fun provideRemoteBuilder(@Named("MapPlaceSearch") okHttpClient: OkHttpClient): Retrofit {
         return Retrofit.Builder()
             .baseUrl(BASE_URL)
             .client(okHttpClient)
-            .addConverterFactory(Json.asConverterFactory(contentType))
+            .addConverterFactory(json.asConverterFactory(contentType))
             .build()
     }
 
     @Provides
-    fun provideUserService(@Named("RemoteDatabase") remoteBuilder: Retrofit): UserService =
-        remoteBuilder.create(UserService::class.java)
-
-    @Provides
-    fun provideLogService(@Named("RemoteDatabase") remoteBuilder: Retrofit): LogService =
-        remoteBuilder.create(LogService::class.java)
-
-    @Provides
-    fun providePlaceService(@Named("RemoteDatabase") remoteBuilder: Retrofit): PlaceService =
-        remoteBuilder.create(PlaceService::class.java)
-
-    @Provides
-    fun provideImageService(@Named("RemoteDatabase") remoteBuilder: Retrofit): ImageService =
-        remoteBuilder.create(ImageService::class.java)
+    fun provideMapSearchService(@Named("MapPlaceSearch") remoteBuilder: Retrofit): MapPlaceSearchService =
+        remoteBuilder.create(MapPlaceSearchService::class.java)
 }

--- a/app/src/main/java/com/treasurehunt/di/NetworkModule.kt
+++ b/app/src/main/java/com/treasurehunt/di/NetworkModule.kt
@@ -21,6 +21,7 @@ private const val HEADER_USER_AGENT = "User-Agent"
 private const val APP_NAME = "TreasureHunt"
 private const val BASE_URL = BuildConfig.BASE_URL
 private val contentType = "application/json".toMediaType()
+private const val CLIENT_QUALIFIER_REMOTE_DATABASE = "RemoteDatabase"
 
 @Module
 @InstallIn(SingletonComponent::class)
@@ -28,7 +29,7 @@ object NetworkModule {
 
     @Singleton
     @Provides
-    @Named("RemoteDatabase")
+    @Named(CLIENT_QUALIFIER_REMOTE_DATABASE)
     fun provideClient(): OkHttpClient {
         return OkHttpClient.Builder()
             .addNetworkInterceptor { chain ->
@@ -40,8 +41,10 @@ object NetworkModule {
 
     @Singleton
     @Provides
-    @Named("RemoteDatabase")
-    fun provideRemoteBuilder(@Named("RemoteDatabase") okHttpClient: OkHttpClient): Retrofit {
+    @Named(CLIENT_QUALIFIER_REMOTE_DATABASE)
+    fun provideRemoteBuilder(
+        @Named(CLIENT_QUALIFIER_REMOTE_DATABASE) okHttpClient: OkHttpClient
+    ): Retrofit {
         return Retrofit.Builder()
             .baseUrl(BASE_URL)
             .client(okHttpClient)
@@ -50,18 +53,26 @@ object NetworkModule {
     }
 
     @Provides
-    fun provideUserService(@Named("RemoteDatabase") remoteBuilder: Retrofit): UserService =
+    fun provideUserService(
+        @Named(CLIENT_QUALIFIER_REMOTE_DATABASE) remoteBuilder: Retrofit
+    ): UserService =
         remoteBuilder.create(UserService::class.java)
 
     @Provides
-    fun provideLogService(@Named("RemoteDatabase") remoteBuilder: Retrofit): LogService =
+    fun provideLogService(
+        @Named(CLIENT_QUALIFIER_REMOTE_DATABASE) remoteBuilder: Retrofit
+    ): LogService =
         remoteBuilder.create(LogService::class.java)
 
     @Provides
-    fun providePlaceService(@Named("RemoteDatabase") remoteBuilder: Retrofit): PlaceService =
+    fun providePlaceService(
+        @Named(CLIENT_QUALIFIER_REMOTE_DATABASE) remoteBuilder: Retrofit
+    ): PlaceService =
         remoteBuilder.create(PlaceService::class.java)
 
     @Provides
-    fun provideImageService(@Named("RemoteDatabase") remoteBuilder: Retrofit): ImageService =
+    fun provideImageService(
+        @Named(CLIENT_QUALIFIER_REMOTE_DATABASE) remoteBuilder: Retrofit
+    ): ImageService =
         remoteBuilder.create(ImageService::class.java)
 }

--- a/app/src/main/java/com/treasurehunt/di/RepositoryModule.kt
+++ b/app/src/main/java/com/treasurehunt/di/RepositoryModule.kt
@@ -6,6 +6,8 @@ import com.treasurehunt.data.LogRepository
 import com.treasurehunt.data.LogRepositoryImpl
 import com.treasurehunt.data.UserPreferencesRepository
 import com.treasurehunt.data.UserPreferencesRepositoryImpl
+import com.treasurehunt.data.MapPlaceSearchRepository
+import com.treasurehunt.data.MapPlaceSearchRepositoryImpl
 import com.treasurehunt.data.PlaceRepository
 import com.treasurehunt.data.PlaceRepositoryImpl
 import com.treasurehunt.data.UserRepository
@@ -33,4 +35,7 @@ abstract class RepositoryModule {
 
     @Binds
     abstract fun bindLoginRepository(userPreferencesRepositoryImpl: UserPreferencesRepositoryImpl) : UserPreferencesRepository
+
+    @Binds
+    abstract fun bindMapPlaceSearchRepository(mapPlaceSearchRepositoryImpl: MapPlaceSearchRepositoryImpl): MapPlaceSearchRepository
 }

--- a/app/src/main/java/com/treasurehunt/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/treasurehunt/ui/home/HomeFragment.kt
@@ -57,6 +57,7 @@ class HomeFragment : Fragment(), OnMapReadyCallback {
         super.onViewCreated(view, savedInstanceState)
         initSegmentedButton()
         loadMap()
+        setSearchBar()
     }
 
     override fun onDestroyView() {
@@ -91,15 +92,6 @@ class HomeFragment : Fragment(), OnMapReadyCallback {
         setLocationOverlay()
         showMarkers()
         setSymbolClick()
-
-        binding.tietSearchFriend.setOnEditorActionListener { _, _, _ ->
-            viewLifecycleOwner.lifecycleScope.launch {
-                val keyword = binding.tietSearchFriend.text.toString()
-                val result = viewModel.search(keyword)
-                // TODO: show result
-            }
-            true
-        }
     }
 
     private fun initMap(naverMap: NaverMap) {
@@ -219,5 +211,17 @@ class HomeFragment : Fragment(), OnMapReadyCallback {
             }
             true
         }
+    }
+
+    private fun setSearchBar() {
+        binding.tietSearchFriend.setOnFocusChangeListener { _, hasFocus ->
+            if (hasFocus) {
+                findNavController().navigate(R.id.action_homeFragment_to_searchMapPlaceFragment)
+            }
+        }
+    }
+
+    companion object {
+        private const val LOCATION_PERMISSION_REQUEST_CODE = 1000
     }
 }

--- a/app/src/main/java/com/treasurehunt/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/treasurehunt/ui/home/HomeFragment.kt
@@ -9,7 +9,6 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.ImageView
 import androidx.activity.result.contract.ActivityResultContracts.RequestPermission
 import androidx.core.content.ContextCompat
 import androidx.core.text.HtmlCompat
@@ -217,8 +216,10 @@ class HomeFragment : Fragment(), OnMapReadyCallback {
 
         disableAutoTracking()
 
-        val cameraUpdate =
-            CameraUpdate.scrollAndZoomTo(mapPlace.position, CAMERA_ZOOM_LEVEL_AT_SELECTED_MAP_PLACE)
+        val cameraUpdate = CameraUpdate.scrollAndZoomTo(
+            mapPlace.position,
+            CAMERA_ZOOM_LEVEL_AT_SELECTED_MAP_PLACE
+        )
         map.moveCamera(cameraUpdate)
 
         showSearchResultPin(mapPlace)
@@ -249,25 +250,26 @@ class HomeFragment : Fragment(), OnMapReadyCallback {
                 override fun getView(p0: InfoWindow): View {
                     val binding = ViewInfoWindowSelectedSearchResultBinding.inflate(
                         LayoutInflater.from(context)
-                    ).apply {
-                        tvTitle.text =
-                            HtmlCompat.fromHtml(mapPlace.title, HtmlCompat.FROM_HTML_MODE_LEGACY)
-                        tvRoadAddress.text = mapPlace.roadAddress
-                        tvCategory.text = mapPlace.category?.substringAfter(
-                            MAP_PLACE_CATEGORY_SEPARATOR
-                        )
-                        tvDistance.text = mapPlace.distance
-                            ?: context.getString(R.string.search_map_place_unknown)
-
-                        test(ivTest, mapPlace)
-                    }
+                    )
+                        .bind(mapPlace, context)
                     return binding.root
                 }
             }
         }
     }
 
-    private fun test(imageView: ImageView, mapPlace: MapPlaceModel) {
+    private fun ViewInfoWindowSelectedSearchResultBinding.bind(
+        mapPlace: MapPlaceModel,
+        context: Context
+    ) = apply {
+        tvTitle.text =
+            HtmlCompat.fromHtml(mapPlace.title, HtmlCompat.FROM_HTML_MODE_LEGACY)
+        tvRoadAddress.text = mapPlace.roadAddress
+        tvCategory.text = mapPlace.category?.substringAfter(
+            MAP_PLACE_CATEGORY_SEPARATOR
+        )
+        tvDistance.text = mapPlace.distance
+            ?: context.getString(R.string.search_map_place_unknown)
     }
 
     private fun setSearchBar() {

--- a/app/src/main/java/com/treasurehunt/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/treasurehunt/ui/home/HomeFragment.kt
@@ -45,11 +45,8 @@ class HomeFragment : Fragment(), OnMapReadyCallback {
         registerForActivityResult(RequestPermission()) { isGranted ->
             setLocationTrackingMode(isGranted)
         }
-<<<<<<< HEAD
     private val args: HomeFragmentArgs by navArgs()
-=======
     private lateinit var latlng: LatLng
->>>>>>> cd26046 (임시커밋)
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?

--- a/app/src/main/java/com/treasurehunt/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/treasurehunt/ui/home/HomeFragment.kt
@@ -16,6 +16,7 @@ import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
+import com.naver.maps.geometry.LatLng
 import com.naver.maps.map.LocationTrackingMode
 import com.naver.maps.map.MapFragment
 import com.naver.maps.map.NaverMap
@@ -44,7 +45,11 @@ class HomeFragment : Fragment(), OnMapReadyCallback {
         registerForActivityResult(RequestPermission()) { isGranted ->
             setLocationTrackingMode(isGranted)
         }
+<<<<<<< HEAD
     private val args: HomeFragmentArgs by navArgs()
+=======
+    private lateinit var latlng: LatLng
+>>>>>>> cd26046 (임시커밋)
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?
@@ -57,7 +62,6 @@ class HomeFragment : Fragment(), OnMapReadyCallback {
         super.onViewCreated(view, savedInstanceState)
         initSegmentedButton()
         loadMap()
-        setSearchBar()
     }
 
     override fun onDestroyView() {
@@ -90,8 +94,10 @@ class HomeFragment : Fragment(), OnMapReadyCallback {
         initMap(naverMap)
         handleLocationAccessPermission()
         setLocationOverlay()
-        showMarkers()
+        setCurrentPosition()
+        setSearchBar()
         setSymbolClick()
+        showMarkers()
     }
 
     private fun initMap(naverMap: NaverMap) {
@@ -123,6 +129,24 @@ class HomeFragment : Fragment(), OnMapReadyCallback {
         locationOverlay.icon =
             OverlayImage.fromResource(R.drawable.ic_launcher_foreground)
         locationOverlay.anchor = PointF(0.5f, 1f)
+    }
+
+    private fun setCurrentPosition() {
+        latlng = map.locationOverlay.position
+
+        map.addOnLocationChangeListener { position ->
+            latlng = LatLng(position.latitude, position.longitude)
+        }
+    }
+
+    private fun setSearchBar() {
+        binding.tietSearchFriend.setOnFocusChangeListener { _, hasFocus ->
+            if (hasFocus) {
+                val action =
+                    HomeFragmentDirections.actionHomeFragmentToSearchMapPlaceFragment(latlng)
+                findNavController().navigate(action)
+            }
+        }
     }
 
     private fun setSymbolClick() {
@@ -211,17 +235,5 @@ class HomeFragment : Fragment(), OnMapReadyCallback {
             }
             true
         }
-    }
-
-    private fun setSearchBar() {
-        binding.tietSearchFriend.setOnFocusChangeListener { _, hasFocus ->
-            if (hasFocus) {
-                findNavController().navigate(R.id.action_homeFragment_to_searchMapPlaceFragment)
-            }
-        }
-    }
-
-    companion object {
-        private const val LOCATION_PERMISSION_REQUEST_CODE = 1000
     }
 }

--- a/app/src/main/java/com/treasurehunt/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/treasurehunt/ui/home/HomeFragment.kt
@@ -152,12 +152,10 @@ class HomeFragment : Fragment(), OnMapReadyCallback {
     }
 
     private fun setSearchBar() {
-        binding.tietSearchFriend.setOnFocusChangeListener { _, hasFocus ->
-            if (hasFocus) {
-                val action =
-                    HomeFragmentDirections.actionHomeFragmentToSearchMapPlaceFragment(userPosition)
-                findNavController().navigate(action)
-            }
+        binding.btnSearchBar.setOnClickListener {
+            val action =
+                HomeFragmentDirections.actionHomeFragmentToSearchMapPlaceFragment(userPosition)
+            findNavController().navigate(action)
         }
     }
 

--- a/app/src/main/java/com/treasurehunt/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/treasurehunt/ui/home/HomeFragment.kt
@@ -91,6 +91,15 @@ class HomeFragment : Fragment(), OnMapReadyCallback {
         setLocationOverlay()
         showMarkers()
         setSymbolClick()
+
+        binding.tietSearchFriend.setOnEditorActionListener { _, _, _ ->
+            viewLifecycleOwner.lifecycleScope.launch {
+                val keyword = binding.tietSearchFriend.text.toString()
+                val result = viewModel.search(keyword)
+                // TODO: show result
+            }
+            true
+        }
     }
 
     private fun initMap(naverMap: NaverMap) {

--- a/app/src/main/java/com/treasurehunt/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/treasurehunt/ui/home/HomeFragment.kt
@@ -50,8 +50,9 @@ import com.treasurehunt.util.MAP_PLACE_CATEGORY_SEPARATOR
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
 
-
 private const val LOCATION_PERMISSION_REQUEST_CODE = 1000
+private const val CAMERA_MAX_ZOOM_LEVEL = 21.0
+private const val CAMERA_ZOOM_LEVEL_AT_SELECTED_MAP_PLACE = CAMERA_MAX_ZOOM_LEVEL - 3
 
 @AndroidEntryPoint
 class HomeFragment : Fragment(), OnMapReadyCallback {
@@ -216,7 +217,8 @@ class HomeFragment : Fragment(), OnMapReadyCallback {
 
         disableAutoTracking()
 
-        val cameraUpdate = CameraUpdate.scrollTo(mapPlace.position)
+        val cameraUpdate =
+            CameraUpdate.scrollAndZoomTo(mapPlace.position, CAMERA_ZOOM_LEVEL_AT_SELECTED_MAP_PLACE)
         map.moveCamera(cameraUpdate)
 
         showSearchResultPin(mapPlace)

--- a/app/src/main/java/com/treasurehunt/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/treasurehunt/ui/home/HomeViewModel.kt
@@ -9,11 +9,9 @@ import com.naver.maps.map.overlay.Marker
 import com.naver.maps.map.overlay.OverlayImage
 import com.treasurehunt.R
 import com.treasurehunt.data.LogRepository
-import com.treasurehunt.data.MapPlaceSearchRepository
 import com.treasurehunt.data.PlaceRepository
 import com.treasurehunt.data.UserRepository
 import com.treasurehunt.data.local.model.PlaceEntity
-import com.treasurehunt.data.remote.model.MapPlaceSearchResultDTO
 import com.treasurehunt.data.remote.model.PlaceDTO
 import com.treasurehunt.data.remote.model.UserDTO
 import com.treasurehunt.ui.model.HomeMapUiState
@@ -42,7 +40,6 @@ class HomeViewModel @Inject constructor(
     private val logRepo: LogRepository,
     private val placeRepo: PlaceRepository,
     private val userRepo: UserRepository,
-    private val mapPlaceSearchRepo: MapPlaceSearchRepository,
     private val connectivityRepo: ConnectivityRepository
 ) :
     ViewModel() {
@@ -172,9 +169,5 @@ class HomeViewModel @Inject constructor(
         this.icon = icon
         this.width = width
         this.height = height
-    }
-
-    suspend fun search(keyword: String): MapPlaceSearchResultDTO {
-        return mapPlaceSearchRepo.getMapPlaceByKeyword(keyword)
     }
 }

--- a/app/src/main/java/com/treasurehunt/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/treasurehunt/ui/home/HomeViewModel.kt
@@ -34,6 +34,8 @@ import kotlinx.coroutines.tasks.await
 import java.io.IOException
 import javax.inject.Inject
 
+private const val SELECTED_SEARCH_RESULT_PIN_WIDTH = 160
+private const val SELECTED_SEARCH_RESULT_PIN_HEIGHT = 160
 private const val VISIT_MARKER_WIDTH = 116
 private const val VISIT_MARKER_HEIGHT = 80
 private const val PLAN_MARKER_WIDTH = 96
@@ -51,6 +53,8 @@ class HomeViewModel @Inject constructor(
     private val _uiState: MutableStateFlow<HomeMapUiState> = MutableStateFlow(HomeMapUiState())
     val uiState: StateFlow<HomeMapUiState> = _uiState.asStateFlow()
     private var fetchJob: Job? = null
+    private val _searchResultPins: MutableList<Marker> = mutableListOf()
+    val searchResultPins: List<Marker> get() = _searchResultPins.toList()
 
     init {
         initUser()
@@ -113,6 +117,20 @@ class HomeViewModel @Inject constructor(
 
     suspend fun updatePlace(id: String, place: PlaceDTO) {
         placeRepo.update(id, place)
+    }
+
+    fun getPin(position: LatLng): Marker {
+        _searchResultPins += Marker(position).apply {
+            icon = OverlayImage.fromResource(R.drawable.ic_pin)
+            width = SELECTED_SEARCH_RESULT_PIN_WIDTH
+            height = SELECTED_SEARCH_RESULT_PIN_HEIGHT
+        }
+
+        return searchResultPins.last()
+    }
+
+    fun removePin() {
+        _searchResultPins.removeLastOrNull()
     }
 
     private fun getAllMarkers() {

--- a/app/src/main/java/com/treasurehunt/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/treasurehunt/ui/home/HomeViewModel.kt
@@ -9,9 +9,11 @@ import com.naver.maps.map.overlay.Marker
 import com.naver.maps.map.overlay.OverlayImage
 import com.treasurehunt.R
 import com.treasurehunt.data.LogRepository
+import com.treasurehunt.data.MapPlaceSearchRepository
 import com.treasurehunt.data.PlaceRepository
 import com.treasurehunt.data.UserRepository
 import com.treasurehunt.data.local.model.PlaceEntity
+import com.treasurehunt.data.remote.model.MapPlaceSearchResultDTO
 import com.treasurehunt.data.remote.model.PlaceDTO
 import com.treasurehunt.data.remote.model.UserDTO
 import com.treasurehunt.ui.model.HomeMapUiState
@@ -40,6 +42,7 @@ class HomeViewModel @Inject constructor(
     private val logRepo: LogRepository,
     private val placeRepo: PlaceRepository,
     private val userRepo: UserRepository,
+    private val mapPlaceSearchRepo: MapPlaceSearchRepository,
     private val connectivityRepo: ConnectivityRepository
 ) :
     ViewModel() {
@@ -169,5 +172,9 @@ class HomeViewModel @Inject constructor(
         this.icon = icon
         this.width = width
         this.height = height
+    }
+
+    suspend fun search(keyword: String): MapPlaceSearchResultDTO {
+        return mapPlaceSearchRepo.getMapPlaceByKeyword(keyword)
     }
 }

--- a/app/src/main/java/com/treasurehunt/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/treasurehunt/ui/home/HomeViewModel.kt
@@ -34,7 +34,7 @@ import kotlinx.coroutines.tasks.await
 import java.io.IOException
 import javax.inject.Inject
 
-private const val SELECTED_SEARCH_RESULT_PIN_WIDTH = 160
+private const val SELECTED_SEARCH_RESULT_PIN_WIDTH = 120
 private const val SELECTED_SEARCH_RESULT_PIN_HEIGHT = 160
 private const val VISIT_MARKER_WIDTH = 116
 private const val VISIT_MARKER_HEIGHT = 80

--- a/app/src/main/java/com/treasurehunt/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/treasurehunt/ui/home/HomeViewModel.kt
@@ -4,6 +4,8 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.google.firebase.auth.ktx.auth
 import com.google.firebase.ktx.Firebase
+import com.google.firebase.storage.StorageReference
+import com.google.firebase.storage.ktx.storage
 import com.naver.maps.geometry.LatLng
 import com.naver.maps.map.overlay.Marker
 import com.naver.maps.map.overlay.OverlayImage
@@ -16,6 +18,7 @@ import com.treasurehunt.data.remote.model.PlaceDTO
 import com.treasurehunt.data.remote.model.UserDTO
 import com.treasurehunt.ui.model.HomeMapUiState
 import com.treasurehunt.util.ConnectivityRepository
+import com.treasurehunt.util.STORAGE_LOCATION_PROFILE_IMAGE
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
@@ -27,6 +30,7 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.tasks.await
 import java.io.IOException
 import javax.inject.Inject
 
@@ -78,6 +82,13 @@ class HomeViewModel @Inject constructor(
     }
 
     suspend fun getRemoteUser(uid: String): UserDTO = userRepo.getRemoteUserById(uid)
+
+    suspend fun getUserProfileImageStorageRef(uid: String): StorageReference? =
+        Firebase.storage.reference.child(uid).child(STORAGE_LOCATION_PROFILE_IMAGE)
+            .list(1)
+            .await()
+            .items
+            .singleOrNull()
 
     suspend fun updateUser(uid: String, user: UserDTO) {
         userRepo.update(uid, user)

--- a/app/src/main/java/com/treasurehunt/ui/model/MapPlaceModel.kt
+++ b/app/src/main/java/com/treasurehunt/ui/model/MapPlaceModel.kt
@@ -1,0 +1,13 @@
+package com.treasurehunt.ui.model
+
+data class MapPlaceModel(
+    val title: String,
+    val link: String? = null,
+    val category: String? = null,
+    val description: String? = null,
+    val telephone: String? = null,
+    val address: String? = null,
+    val roadAddress: String? = null,
+    val mapx: String? = null,
+    val mapy: String? = null
+)

--- a/app/src/main/java/com/treasurehunt/ui/model/MapPlaceModel.kt
+++ b/app/src/main/java/com/treasurehunt/ui/model/MapPlaceModel.kt
@@ -1,5 +1,10 @@
 package com.treasurehunt.ui.model
 
+import android.os.Parcelable
+import com.naver.maps.geometry.LatLng
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
 data class MapPlaceModel(
     val title: String,
     val link: String? = null,
@@ -9,5 +14,7 @@ data class MapPlaceModel(
     val address: String? = null,
     val roadAddress: String? = null,
     val mapx: String? = null,
-    val mapy: String? = null
-)
+    val mapy: String? = null,
+    val position: LatLng? = null,
+    val distance: String? = null
+) : Parcelable

--- a/app/src/main/java/com/treasurehunt/ui/model/SearchMapPlaceUiState.kt
+++ b/app/src/main/java/com/treasurehunt/ui/model/SearchMapPlaceUiState.kt
@@ -1,0 +1,5 @@
+package com.treasurehunt.ui.model
+
+data class MapPlaceSearchUiState(
+    val searchResults: List<MapPlaceModel>
+)

--- a/app/src/main/java/com/treasurehunt/ui/searchmapplace/MapPlaceClickListener.kt
+++ b/app/src/main/java/com/treasurehunt/ui/searchmapplace/MapPlaceClickListener.kt
@@ -1,0 +1,8 @@
+package com.treasurehunt.ui.searchmapplace
+
+import com.treasurehunt.ui.model.MapPlaceModel
+
+fun interface MapPlaceClickListener {
+
+    fun onClick(mapPlaceModel: MapPlaceModel)
+}

--- a/app/src/main/java/com/treasurehunt/ui/searchmapplace/SearchMapPlaceFragment.kt
+++ b/app/src/main/java/com/treasurehunt/ui/searchmapplace/SearchMapPlaceFragment.kt
@@ -1,0 +1,59 @@
+package com.treasurehunt.ui.searchmapplace
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
+import androidx.lifecycle.lifecycleScope
+import androidx.navigation.fragment.findNavController
+import com.treasurehunt.R
+import com.treasurehunt.databinding.FragmentSearchMapPlaceBinding
+import com.treasurehunt.ui.searchmapplace.adapter.SearchMapPlaceAdapter
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.launch
+
+@AndroidEntryPoint
+class SearchMapPlaceFragment : Fragment() {
+
+    private var _binding: FragmentSearchMapPlaceBinding? = null
+    private val binding get() = _binding!!
+    private val viewModel: SearchMapPlaceViewModel by viewModels()
+    private lateinit var adapter: SearchMapPlaceAdapter
+
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        _binding = FragmentSearchMapPlaceBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        initAdapter()
+        binding.tietSearchMapPlace.setOnEditorActionListener { _, _, _ ->
+            viewLifecycleOwner.lifecycleScope.launch {
+                val keyword = binding.tietSearchMapPlace.text.toString()
+                val result = viewModel.search(keyword)
+                adapter.submitList(result)
+            }
+            true
+        }
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+
+    private fun initAdapter() {
+        val clickListener = MapPlaceClickListener {
+            findNavController().navigate(R.id.action_searchMapPlaceFragment_to_homeFragment)
+            // TODO: 좌표 전달받아 지도에서 그리로 이동
+        }
+        adapter = SearchMapPlaceAdapter(clickListener)
+        binding.rvSearchResult.adapter = adapter
+    }
+}

--- a/app/src/main/java/com/treasurehunt/ui/searchmapplace/SearchMapPlaceFragment.kt
+++ b/app/src/main/java/com/treasurehunt/ui/searchmapplace/SearchMapPlaceFragment.kt
@@ -8,6 +8,7 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
+import androidx.navigation.fragment.navArgs
 import com.treasurehunt.R
 import com.treasurehunt.databinding.FragmentSearchMapPlaceBinding
 import com.treasurehunt.ui.searchmapplace.adapter.SearchMapPlaceAdapter
@@ -21,6 +22,7 @@ class SearchMapPlaceFragment : Fragment() {
     private val binding get() = _binding!!
     private val viewModel: SearchMapPlaceViewModel by viewModels()
     private lateinit var adapter: SearchMapPlaceAdapter
+    private val args: SearchMapPlaceFragmentArgs by navArgs()
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
@@ -53,7 +55,7 @@ class SearchMapPlaceFragment : Fragment() {
             findNavController().navigate(R.id.action_searchMapPlaceFragment_to_homeFragment)
             // TODO: 좌표 전달받아 지도에서 그리로 이동
         }
-        adapter = SearchMapPlaceAdapter(clickListener)
+        adapter = SearchMapPlaceAdapter(args.latlng, clickListener)
         binding.rvSearchResult.adapter = adapter
     }
 }

--- a/app/src/main/java/com/treasurehunt/ui/searchmapplace/SearchMapPlaceFragment.kt
+++ b/app/src/main/java/com/treasurehunt/ui/searchmapplace/SearchMapPlaceFragment.kt
@@ -59,7 +59,7 @@ class SearchMapPlaceFragment : Fragment() {
     private fun getClickListener() = MapPlaceClickListener { mapPlace ->
         val mapPlacePosition = convertMapXYToLatLng(mapPlace.mapx to mapPlace.mapy)
         val action = SearchMapPlaceFragmentDirections.actionSearchMapPlaceFragmentToHomeFragment(
-            mapPlacePosition
+            mapPlacePosition = mapPlacePosition
         )
         findNavController().navigate(action)
     }

--- a/app/src/main/java/com/treasurehunt/ui/searchmapplace/SearchMapPlaceFragment.kt
+++ b/app/src/main/java/com/treasurehunt/ui/searchmapplace/SearchMapPlaceFragment.kt
@@ -9,9 +9,9 @@ import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
-import com.treasurehunt.R
 import com.treasurehunt.databinding.FragmentSearchMapPlaceBinding
 import com.treasurehunt.ui.searchmapplace.adapter.SearchMapPlaceAdapter
+import com.treasurehunt.util.convertMapXYToLatLng
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
 
@@ -51,11 +51,15 @@ class SearchMapPlaceFragment : Fragment() {
     }
 
     private fun initAdapter() {
-        val clickListener = MapPlaceClickListener {
-            findNavController().navigate(R.id.action_searchMapPlaceFragment_to_homeFragment)
-            // TODO: 좌표 전달받아 지도에서 그리로 이동
+        val clickListener = MapPlaceClickListener { mapPlace ->
+            val mapPlacePosition = convertMapXYToLatLng(mapPlace.mapx to mapPlace.mapy)
+            val action =
+                SearchMapPlaceFragmentDirections.actionSearchMapPlaceFragmentToHomeFragment(
+                    mapPlacePosition
+                )
+            findNavController().navigate(action)
         }
-        adapter = SearchMapPlaceAdapter(args.latlng, clickListener)
+        adapter = SearchMapPlaceAdapter(args.userPosition, clickListener)
         binding.rvSearchResult.adapter = adapter
     }
 }

--- a/app/src/main/java/com/treasurehunt/ui/searchmapplace/SearchMapPlaceFragment.kt
+++ b/app/src/main/java/com/treasurehunt/ui/searchmapplace/SearchMapPlaceFragment.kt
@@ -16,6 +16,7 @@ import com.treasurehunt.databinding.FragmentSearchMapPlaceBinding
 import com.treasurehunt.ui.model.MapPlaceModel
 import com.treasurehunt.ui.searchmapplace.adapter.SearchMapPlaceAdapter
 import com.treasurehunt.util.convertMapXYToLatLng
+import com.treasurehunt.util.getDistance
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
@@ -58,8 +59,12 @@ class SearchMapPlaceFragment : Fragment() {
 
     private fun getClickListener() = MapPlaceClickListener { mapPlace ->
         val mapPlacePosition = convertMapXYToLatLng(mapPlace.mapx to mapPlace.mapy)
+        val distance = getDistance(mapPlace.mapx to mapPlace.mapy, args.userPosition)
         val action = SearchMapPlaceFragmentDirections.actionSearchMapPlaceFragmentToHomeFragment(
-            mapPlacePosition = mapPlacePosition
+            mapPlace = mapPlace.copy(
+                position = mapPlacePosition,
+                distance = distance
+            )
         )
         findNavController().navigate(action)
     }

--- a/app/src/main/java/com/treasurehunt/ui/searchmapplace/SearchMapPlaceViewModel.kt
+++ b/app/src/main/java/com/treasurehunt/ui/searchmapplace/SearchMapPlaceViewModel.kt
@@ -1,0 +1,35 @@
+package com.treasurehunt.ui.searchmapplace
+
+import androidx.lifecycle.ViewModel
+import com.treasurehunt.data.LogRepository
+import com.treasurehunt.data.MapPlaceSearchRepository
+import com.treasurehunt.data.PlaceRepository
+import com.treasurehunt.data.UserRepository
+import com.treasurehunt.data.remote.model.toMapPlaceModel
+import com.treasurehunt.ui.model.MapPlaceModel
+import com.treasurehunt.ui.model.MapPlaceSearchUiState
+import com.treasurehunt.util.ConnectivityRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import javax.inject.Inject
+
+@HiltViewModel
+class SearchMapPlaceViewModel @Inject constructor(
+    private val logRepo: LogRepository,
+    private val placeRepo: PlaceRepository,
+    private val userRepo: UserRepository,
+    private val mapPlaceSearchRepo: MapPlaceSearchRepository,
+    private val connectivityRepo: ConnectivityRepository
+) :
+    ViewModel() {
+
+    private val _uiState = MutableStateFlow(MapPlaceSearchUiState(listOf()))
+    val uiState: StateFlow<MapPlaceSearchUiState> = _uiState
+
+    suspend fun search(keyword: String): List<MapPlaceModel> {
+        return mapPlaceSearchRepo.getMapPlaceByKeyword(keyword)
+            .items
+            .map { it.toMapPlaceModel() }
+    }
+}

--- a/app/src/main/java/com/treasurehunt/ui/searchmapplace/adapter/SearchMapPlaceAdapter.kt
+++ b/app/src/main/java/com/treasurehunt/ui/searchmapplace/adapter/SearchMapPlaceAdapter.kt
@@ -1,0 +1,69 @@
+package com.treasurehunt.ui.searchmapplace.adapter
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.core.text.HtmlCompat
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import com.treasurehunt.databinding.ItemSearchMapPlaceBinding
+import com.treasurehunt.ui.model.MapPlaceModel
+import com.treasurehunt.ui.searchmapplace.MapPlaceClickListener
+
+class SearchMapPlaceAdapter(private val clickListener: MapPlaceClickListener) :
+    ListAdapter<MapPlaceModel, SearchMapPlaceAdapter.ViewHolder>(diffutil) {
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
+        return ViewHolder.from(parent)
+    }
+
+    override fun onBindViewHolder(holder: ViewHolder, position: Int) {
+        holder.bind(currentList[position], clickListener)
+    }
+
+    class ViewHolder(private val binding: ItemSearchMapPlaceBinding) :
+        RecyclerView.ViewHolder(binding.root) {
+
+        fun bind(mapPlace: MapPlaceModel, clickListener: MapPlaceClickListener) {
+            with(binding) {
+                tvTitle.text = HtmlCompat.fromHtml(mapPlace.title, HtmlCompat.FROM_HTML_MODE_LEGACY)
+                tvRoadAddress.text = mapPlace.roadAddress
+                tvCategory.text = mapPlace.category?.substringAfter('>') // trim
+
+                // distance
+
+                root.setOnClickListener {
+                    clickListener.onClick(mapPlace)
+                }
+            }
+        }
+
+        companion object {
+            fun from(parent: ViewGroup): ViewHolder {
+                return ViewHolder(
+                    ItemSearchMapPlaceBinding.inflate(
+                        LayoutInflater.from(parent.context),
+                        parent,
+                        false
+                    )
+                )
+            }
+        }
+    }
+
+    companion object {
+        private val diffutil = object : DiffUtil.ItemCallback<MapPlaceModel>() {
+            override fun areItemsTheSame(oldItem: MapPlaceModel, newItem: MapPlaceModel): Boolean {
+                return oldItem.title == newItem.title
+            }
+
+            override fun areContentsTheSame(
+                oldItem: MapPlaceModel,
+                newItem: MapPlaceModel
+            ): Boolean {
+                return oldItem == newItem
+            }
+
+        }
+    }
+}

--- a/app/src/main/java/com/treasurehunt/ui/searchmapplace/adapter/SearchMapPlaceAdapter.kt
+++ b/app/src/main/java/com/treasurehunt/ui/searchmapplace/adapter/SearchMapPlaceAdapter.kt
@@ -6,11 +6,19 @@ import androidx.core.text.HtmlCompat
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
+import com.naver.maps.geometry.LatLng
+import com.treasurehunt.R
 import com.treasurehunt.databinding.ItemSearchMapPlaceBinding
 import com.treasurehunt.ui.model.MapPlaceModel
 import com.treasurehunt.ui.searchmapplace.MapPlaceClickListener
+import com.treasurehunt.util.convertNaverLocalSearchMapXYToLatLng
 
-class SearchMapPlaceAdapter(private val clickListener: MapPlaceClickListener) :
+private const val CATEGORY_SEPARATOR = '>'
+
+class SearchMapPlaceAdapter(
+    private val userPosition: LatLng,
+    private val clickListener: MapPlaceClickListener
+) :
     ListAdapter<MapPlaceModel, SearchMapPlaceAdapter.ViewHolder>(diffutil) {
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
@@ -18,25 +26,35 @@ class SearchMapPlaceAdapter(private val clickListener: MapPlaceClickListener) :
     }
 
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
-        holder.bind(currentList[position], clickListener)
+        holder.bind(currentList[position], userPosition, clickListener)
     }
 
     class ViewHolder(private val binding: ItemSearchMapPlaceBinding) :
         RecyclerView.ViewHolder(binding.root) {
 
-        fun bind(mapPlace: MapPlaceModel, clickListener: MapPlaceClickListener) {
+        fun bind(
+            mapPlace: MapPlaceModel,
+            userPosition: LatLng,
+            clickListener: MapPlaceClickListener
+        ) {
             with(binding) {
                 tvTitle.text = HtmlCompat.fromHtml(mapPlace.title, HtmlCompat.FROM_HTML_MODE_LEGACY)
                 tvRoadAddress.text = mapPlace.roadAddress
-                tvCategory.text = mapPlace.category?.substringAfter('>') // trim
-
-                // distance
+                tvCategory.text = mapPlace.category?.substringAfter(CATEGORY_SEPARATOR)
+                tvDistance.text =
+                    getDistance(mapPlace.mapx, mapPlace.mapy, userPosition)
+                        ?: itemView.context.getString(R.string.search_map_place_unknown)
 
                 root.setOnClickListener {
                     clickListener.onClick(mapPlace)
                 }
             }
         }
+
+        private fun getDistance(x: String?, y: String?, other: LatLng) =
+            convertNaverLocalSearchMapXYToLatLng(x, y)
+                ?.distanceTo(other)
+                ?.toString()
 
         companion object {
             fun from(parent: ViewGroup): ViewHolder {

--- a/app/src/main/java/com/treasurehunt/ui/searchmapplace/adapter/SearchMapPlaceAdapter.kt
+++ b/app/src/main/java/com/treasurehunt/ui/searchmapplace/adapter/SearchMapPlaceAdapter.kt
@@ -11,7 +11,8 @@ import com.treasurehunt.R
 import com.treasurehunt.databinding.ItemSearchMapPlaceBinding
 import com.treasurehunt.ui.model.MapPlaceModel
 import com.treasurehunt.ui.searchmapplace.MapPlaceClickListener
-import com.treasurehunt.util.convertNaverLocalSearchMapXYToLatLng
+import com.treasurehunt.util.convertMapXYToLatLng
+import com.treasurehunt.util.formatDistance
 
 private const val CATEGORY_SEPARATOR = '>'
 
@@ -41,9 +42,8 @@ class SearchMapPlaceAdapter(
                 tvTitle.text = HtmlCompat.fromHtml(mapPlace.title, HtmlCompat.FROM_HTML_MODE_LEGACY)
                 tvRoadAddress.text = mapPlace.roadAddress
                 tvCategory.text = mapPlace.category?.substringAfter(CATEGORY_SEPARATOR)
-                tvDistance.text =
-                    getDistance(mapPlace.mapx, mapPlace.mapy, userPosition)
-                        ?: itemView.context.getString(R.string.search_map_place_unknown)
+                tvDistance.text = getDistance(mapPlace.mapx to mapPlace.mapy, userPosition)
+                    ?: itemView.context.getString(R.string.search_map_place_unknown)
 
                 root.setOnClickListener {
                     clickListener.onClick(mapPlace)
@@ -51,10 +51,11 @@ class SearchMapPlaceAdapter(
             }
         }
 
-        private fun getDistance(x: String?, y: String?, other: LatLng) =
-            convertNaverLocalSearchMapXYToLatLng(x, y)
+        private fun getDistance(xy: Pair<String?, String?>, other: LatLng) =
+            convertMapXYToLatLng(xy)
                 ?.distanceTo(other)
-                ?.toString()
+                ?.toLong()
+                ?.let(::formatDistance)
 
         companion object {
             fun from(parent: ViewGroup): ViewHolder {
@@ -81,7 +82,6 @@ class SearchMapPlaceAdapter(
             ): Boolean {
                 return oldItem == newItem
             }
-
         }
     }
 }

--- a/app/src/main/java/com/treasurehunt/ui/searchmapplace/adapter/SearchMapPlaceAdapter.kt
+++ b/app/src/main/java/com/treasurehunt/ui/searchmapplace/adapter/SearchMapPlaceAdapter.kt
@@ -11,8 +11,7 @@ import com.treasurehunt.R
 import com.treasurehunt.databinding.ItemSearchMapPlaceBinding
 import com.treasurehunt.ui.model.MapPlaceModel
 import com.treasurehunt.ui.searchmapplace.MapPlaceClickListener
-import com.treasurehunt.util.convertMapXYToLatLng
-import com.treasurehunt.util.formatDistance
+import com.treasurehunt.util.getDistance
 
 private const val CATEGORY_SEPARATOR = '>'
 
@@ -50,12 +49,6 @@ class SearchMapPlaceAdapter(
                 }
             }
         }
-
-        private fun getDistance(xy: Pair<String?, String?>, other: LatLng) =
-            convertMapXYToLatLng(xy)
-                ?.distanceTo(other)
-                ?.toLong()
-                ?.let(::formatDistance)
 
         companion object {
             fun from(parent: ViewGroup): ViewHolder {

--- a/app/src/main/java/com/treasurehunt/ui/searchmapplace/adapter/SearchMapPlaceAdapter.kt
+++ b/app/src/main/java/com/treasurehunt/ui/searchmapplace/adapter/SearchMapPlaceAdapter.kt
@@ -11,9 +11,8 @@ import com.treasurehunt.R
 import com.treasurehunt.databinding.ItemSearchMapPlaceBinding
 import com.treasurehunt.ui.model.MapPlaceModel
 import com.treasurehunt.ui.searchmapplace.MapPlaceClickListener
+import com.treasurehunt.util.MAP_PLACE_CATEGORY_SEPARATOR
 import com.treasurehunt.util.getDistance
-
-private const val CATEGORY_SEPARATOR = '>'
 
 class SearchMapPlaceAdapter(
     private val userPosition: LatLng,
@@ -40,7 +39,7 @@ class SearchMapPlaceAdapter(
             with(binding) {
                 tvTitle.text = HtmlCompat.fromHtml(mapPlace.title, HtmlCompat.FROM_HTML_MODE_LEGACY)
                 tvRoadAddress.text = mapPlace.roadAddress
-                tvCategory.text = mapPlace.category?.substringAfter(CATEGORY_SEPARATOR)
+                tvCategory.text = mapPlace.category?.substringAfter(MAP_PLACE_CATEGORY_SEPARATOR)
                 tvDistance.text = getDistance(mapPlace.mapx to mapPlace.mapy, userPosition)
                     ?: itemView.context.getString(R.string.search_map_place_unknown)
 

--- a/app/src/main/java/com/treasurehunt/util/Constants.kt
+++ b/app/src/main/java/com/treasurehunt/util/Constants.kt
@@ -9,3 +9,5 @@ internal const val STORAGE_LOCATION_PROFILE_IMAGE = "profile_image"
 internal const val FILENAME_EXTENSION_PNG = ".png"
 
 internal const val MIME_TYPE_IMAGE = "image/*"
+
+internal const val MAP_PLACE_CATEGORY_SEPARATOR = '>'

--- a/app/src/main/java/com/treasurehunt/util/Extensions.kt
+++ b/app/src/main/java/com/treasurehunt/util/Extensions.kt
@@ -1,8 +1,11 @@
 package com.treasurehunt.util
 
+import android.util.Log
 import android.view.View
 import com.google.android.material.snackbar.Snackbar
+import com.naver.maps.geometry.LatLng
 import kotlinx.serialization.json.Json
+import kotlin.math.pow
 
 //******************** View ********************
 
@@ -30,6 +33,7 @@ fun View.hide() {
     visibility = View.GONE
 }
 
+<<<<<<< HEAD
 
 //******************** String ********************
 
@@ -42,3 +46,14 @@ private val json = Json {
 }
 
 internal fun String.extractDigits() = replace("[^0-9]".toRegex(), "")
+
+private val coordMultiplier = 10.0.pow(7)
+
+// currently, mapx, mapy implements WGS84 (LatLng) coord system as integer
+fun convertNaverLocalSearchMapXYToLatLng(mapx: String?, mapy: String?): LatLng? {
+    Log.d("$$", "$mapy || ${mapy?.toLongOrNull()}")
+    val x = mapx?.toLongOrNull() ?: return null
+    val y = mapy?.toLongOrNull() ?: return null
+    Log.d("$$ latlng", "${LatLng(y / coordMultiplier, x / coordMultiplier)}")
+    return LatLng(y / coordMultiplier, x / coordMultiplier)
+}

--- a/app/src/main/java/com/treasurehunt/util/Extensions.kt
+++ b/app/src/main/java/com/treasurehunt/util/Extensions.kt
@@ -1,10 +1,11 @@
 package com.treasurehunt.util
 
-import android.util.Log
 import android.view.View
 import com.google.android.material.snackbar.Snackbar
 import com.naver.maps.geometry.LatLng
 import kotlinx.serialization.json.Json
+import java.math.RoundingMode
+import java.text.DecimalFormat
 import kotlin.math.pow
 
 //******************** View ********************
@@ -33,7 +34,6 @@ fun View.hide() {
     visibility = View.GONE
 }
 
-<<<<<<< HEAD
 
 //******************** String ********************
 
@@ -49,11 +49,26 @@ internal fun String.extractDigits() = replace("[^0-9]".toRegex(), "")
 
 private val coordMultiplier = 10.0.pow(7)
 
-// currently, mapx, mapy implements WGS84 (LatLng) coord system as integer
-fun convertNaverLocalSearchMapXYToLatLng(mapx: String?, mapy: String?): LatLng? {
-    Log.d("$$", "$mapy || ${mapy?.toLongOrNull()}")
-    val x = mapx?.toLongOrNull() ?: return null
-    val y = mapy?.toLongOrNull() ?: return null
-    Log.d("$$ latlng", "${LatLng(y / coordMultiplier, x / coordMultiplier)}")
+// currently, Naver Local Search API mapx, mapy implement WGS84 (LatLng) coord system as integer
+// beware that y, x correspond to lat, lng respectively
+fun convertMapXYToLatLng(xy: Pair<String?, String?>): LatLng? {
+    val x = xy.first?.toLongOrNull() ?: return null
+    val y = xy.second?.toLongOrNull() ?: return null
     return LatLng(y / coordMultiplier, x / coordMultiplier)
 }
+
+private const val KILOMETER_BREAKPOINT = 1000.0
+private const val UNIT_METER = "m"
+private const val UNIT_KILOMETER = "km"
+
+fun formatDistance(meter: Long): String {
+    require(meter >= 0)
+
+    if (meter < KILOMETER_BREAKPOINT) return "${meter}$UNIT_METER"
+
+    return "${(meter / KILOMETER_BREAKPOINT).roundOff()}$UNIT_KILOMETER"
+}
+
+fun Double.roundOff(): Double = DecimalFormat("#.##").apply {
+    roundingMode = RoundingMode.CEILING
+}.format(this).toDouble()

--- a/app/src/main/java/com/treasurehunt/util/Extensions.kt
+++ b/app/src/main/java/com/treasurehunt/util/Extensions.kt
@@ -2,13 +2,11 @@ package com.treasurehunt.util
 
 import android.view.View
 import com.google.android.material.snackbar.Snackbar
-import com.naver.maps.geometry.LatLng
 import kotlinx.serialization.json.Json
 import java.math.RoundingMode
 import java.text.DecimalFormat
-import kotlin.math.pow
 
-//******************** View ********************
+/* ----------- View ----------- */
 
 fun View.showSnackbar(resId: Int) {
     Snackbar.make(
@@ -34,10 +32,9 @@ fun View.hide() {
     visibility = View.GONE
 }
 
+/* ----------- String ----------- */
 
-//******************** String ********************
-
-internal inline fun <reified R> String.convertToDataClass() = json.decodeFromString<R>(this)
+internal fun String.extractDigits() = replace("[^0-9]".toRegex(), "")
 
 private val json = Json {
     isLenient = true
@@ -45,29 +42,9 @@ private val json = Json {
     coerceInputValues = true
 }
 
-internal fun String.extractDigits() = replace("[^0-9]".toRegex(), "")
+internal inline fun <reified R> String.convertToDataClass() = json.decodeFromString<R>(this)
 
-private val coordMultiplier = 10.0.pow(7)
-
-// currently, Naver Local Search API mapx, mapy implement WGS84 (LatLng) coord system as integer
-// beware that y, x correspond to lat, lng respectively
-fun convertMapXYToLatLng(xy: Pair<String?, String?>): LatLng? {
-    val x = xy.first?.toLongOrNull() ?: return null
-    val y = xy.second?.toLongOrNull() ?: return null
-    return LatLng(y / coordMultiplier, x / coordMultiplier)
-}
-
-private const val KILOMETER_BREAKPOINT = 1000.0
-private const val UNIT_METER = "m"
-private const val UNIT_KILOMETER = "km"
-
-fun formatDistance(meter: Long): String {
-    require(meter >= 0)
-
-    if (meter < KILOMETER_BREAKPOINT) return "${meter}$UNIT_METER"
-
-    return "${(meter / KILOMETER_BREAKPOINT).roundOff()}$UNIT_KILOMETER"
-}
+/* ----------- Double ----------- */
 
 fun Double.roundOff(): Double = DecimalFormat("#.##").apply {
     roundingMode = RoundingMode.CEILING

--- a/app/src/main/java/com/treasurehunt/util/Extensions.kt
+++ b/app/src/main/java/com/treasurehunt/util/Extensions.kt
@@ -46,6 +46,13 @@ internal inline fun <reified R> String.convertToDataClass() = json.decodeFromStr
 
 /* ----------- Double ----------- */
 
-fun Double.roundOff(): Double = DecimalFormat("#.##").apply {
-    roundingMode = RoundingMode.CEILING
-}.format(this).toDouble()
+private const val DECIMAL_PLACEHOLDER = "#"
+
+fun Double.roundOff(decimalPlaceCount: Int = 2): Double {
+    require(decimalPlaceCount > 0)
+
+    // Default Format: #.##
+    return DecimalFormat("$DECIMAL_PLACEHOLDER.${DECIMAL_PLACEHOLDER.repeat(decimalPlaceCount)}").apply {
+        roundingMode = RoundingMode.CEILING
+    }.format(this).toDouble()
+}

--- a/app/src/main/java/com/treasurehunt/util/Functions.kt
+++ b/app/src/main/java/com/treasurehunt/util/Functions.kt
@@ -56,6 +56,12 @@ fun convertMapXYToLatLng(xy: Pair<String?, String?>): LatLng? {
 
 /* ----------- 거리 ----------- */
 
+fun getDistance(xy: Pair<String?, String?>, other: LatLng) =
+    convertMapXYToLatLng(xy)
+        ?.distanceTo(other)
+        ?.toLong()
+        ?.let(::formatDistance)
+
 private const val KILOMETER_BREAKPOINT = 1000.0
 private const val UNIT_METER = "m"
 private const val UNIT_KILOMETER = "km"

--- a/app/src/main/res/drawable/ic_arrow_back.xml
+++ b/app/src/main/res/drawable/ic_arrow_back.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#000000"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M17.77,3.77l-1.77,-1.77l-10,10l10,10l1.77,-1.77l-8.23,-8.23z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_location.xml
+++ b/app/src/main/res/drawable/ic_location.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#BDBDBD"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M12,2C8.13,2 5,5.13 5,9c0,5.25 7,13 7,13s7,-7.75 7,-13c0,-3.87 -3.13,-7 -7,-7zM12,11.5c-1.38,0 -2.5,-1.12 -2.5,-2.5s1.12,-2.5 2.5,-2.5 2.5,1.12 2.5,2.5 -1.12,2.5 -2.5,2.5z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_manage_search.xml
+++ b/app/src/main/res/drawable/ic_manage_search.xml
@@ -1,0 +1,5 @@
+<vector android:autoMirrored="true" android:height="24dp"
+    android:tint="#005AFF" android:viewportHeight="24"
+    android:viewportWidth="24" android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M7,9H2V7h5V9zM7,12H2v2h5V12zM20.59,19l-3.83,-3.83C15.96,15.69 15.02,16 14,16c-2.76,0 -5,-2.24 -5,-5s2.24,-5 5,-5s5,2.24 5,5c0,1.02 -0.31,1.96 -0.83,2.75L22,17.59L20.59,19zM17,11c0,-1.65 -1.35,-3 -3,-3s-3,1.35 -3,3s1.35,3 3,3S17,12.65 17,11zM2,19h10v-2H2V19z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_pin.xml
+++ b/app/src/main/res/drawable/ic_pin.xml
@@ -1,0 +1,6 @@
+<vector android:height="24dp" android:tint="#FFC4E7"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white"
+        android:fillType="evenOdd" android:pathData="M16,9V4l1,0c0.55,0 1,-0.45 1,-1v0c0,-0.55 -0.45,-1 -1,-1H7C6.45,2 6,2.45 6,3v0c0,0.55 0.45,1 1,1l1,0v5c0,1.66 -1.34,3 -3,3h0v2h5.97v7l1,1l1,-1v-7H19v-2h0C17.34,12 16,10.66 16,9z"/>
+</vector>

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -16,14 +16,58 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
+    <com.google.android.material.card.MaterialCardView
+        android:id="@+id/cv_searchbox"
+        android:layout_width="match_parent"
+        android:layout_height="50dp"
+        android:layout_marginHorizontal="10dp"
+        android:layout_marginTop="10dp"
+        android:backgroundTint="@color/white"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <ImageView
+        android:id="@+id/iv_search_place"
+        android:layout_width="30dp"
+        android:layout_height="30dp"
+        android:layout_marginStart="20dp"
+        android:layout_marginTop="20dp"
+        android:src="@drawable/ic_manage_search"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <com.google.android.material.textfield.TextInputLayout
+        android:id="@+id/til_search_friend"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="15dp"
+        app:boxStrokeWidth="0dp"
+        app:boxStrokeWidthFocused="0dp"
+        app:hintEnabled="false"
+        app:layout_constraintStart_toEndOf="@id/iv_search_place"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/tiet_search_friend"
+            android:layout_width="250dp"
+            android:layout_height="40dp"
+            android:fontFamily="@font/pretendard"
+            android:hint="@string/home_map_tiet_search_place_hint"
+            android:imeOptions="actionSearch"
+            android:inputType="text"
+            android:padding="0dp"
+            tools:hint="보물찾기할 장소를 검색해 보세요" />
+    </com.google.android.material.textfield.TextInputLayout>
+
     <com.google.android.material.button.MaterialButtonToggleGroup
         android:id="@+id/btn_toggle"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginTop="48dp"
+        android:layout_marginTop="5dp"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent">
+        app:layout_constraintTop_toBottomOf="@id/cv_searchbox">
 
         <com.google.android.material.button.MaterialButton
             android:id="@+id/btn_map"

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -20,7 +20,7 @@
         android:id="@+id/cv_searchbox"
         android:layout_width="match_parent"
         android:layout_height="50dp"
-        android:layout_marginHorizontal="10dp"
+        android:layout_marginHorizontal="20dp"
         android:layout_marginTop="10dp"
         android:backgroundTint="@color/white"
         app:layout_constraintEnd_toEndOf="parent"
@@ -32,33 +32,24 @@
         android:layout_width="30dp"
         android:layout_height="30dp"
         android:layout_marginStart="20dp"
-        android:layout_marginTop="20dp"
         android:src="@drawable/ic_manage_search"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintBottom_toBottomOf="@id/cv_searchbox"
+        app:layout_constraintStart_toStartOf="@id/cv_searchbox"
+        app:layout_constraintTop_toTopOf="@id/cv_searchbox" />
 
-    <com.google.android.material.textfield.TextInputLayout
-        android:id="@+id/til_search_place"
+    <Button
+        android:id="@+id/btn_search_bar"
         android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="15dp"
-        app:boxStrokeWidth="0dp"
-        app:boxStrokeWidthFocused="0dp"
-        app:hintEnabled="false"
+        android:layout_height="50dp"
+        android:layout_marginStart="10dp"
+        android:background="@android:color/transparent"
+        android:fontFamily="@font/pretendard"
+        android:hint="@string/home_map_tiet_search_place_hint"
+        android:padding="0dp"
+        android:textSize="18sp"
+        app:layout_constraintBottom_toBottomOf="@id/cv_searchbox"
         app:layout_constraintStart_toEndOf="@id/iv_search_place"
-        app:layout_constraintTop_toTopOf="parent">
-
-        <com.google.android.material.textfield.TextInputEditText
-            android:id="@+id/tiet_search_friend"
-            android:layout_width="250dp"
-            android:layout_height="40dp"
-            android:fontFamily="@font/pretendard"
-            android:hint="@string/home_map_tiet_search_place_hint"
-            android:imeOptions="actionSearch"
-            android:inputType="text"
-            android:padding="0dp"
-            tools:hint="보물찾기할 장소를 검색해 보세요" />
-    </com.google.android.material.textfield.TextInputLayout>
+        app:layout_constraintTop_toTopOf="@id/cv_searchbox" />
 
     <com.google.android.material.button.MaterialButtonToggleGroup
         android:id="@+id/btn_toggle"

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -38,7 +38,7 @@
         app:layout_constraintTop_toTopOf="parent" />
 
     <com.google.android.material.textfield.TextInputLayout
-        android:id="@+id/til_search_friend"
+        android:id="@+id/til_search_place"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginTop="15dp"

--- a/app/src/main/res/layout/fragment_search_map_place.xml
+++ b/app/src/main/res/layout/fragment_search_map_place.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".ui.searchmapplace.SearchMapPlaceFragment">
+
+    <ImageButton
+        android:id="@+id/ib_back"
+        android:layout_width="40dp"
+        android:layout_height="40dp"
+        android:layout_marginStart="15dp"
+        android:layout_marginTop="15dp"
+        android:background="@android:color/transparent"
+        android:src="@drawable/ic_arrow_back"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <com.google.android.material.textfield.TextInputLayout
+        android:id="@+id/til_search_map_place"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:boxStrokeWidth="0dp"
+        app:boxStrokeWidthFocused="0dp"
+        app:hintEnabled="false"
+        app:layout_constraintStart_toEndOf="@id/ib_back"
+        app:layout_constraintTop_toTopOf="@id/ib_back">
+
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/tiet_search_map_place"
+            android:layout_width="250dp"
+            android:layout_height="40dp"
+            android:fontFamily="@font/pretendard"
+            android:hint="@string/home_map_tiet_search_place_hint"
+            android:imeOptions="actionSearch"
+            android:inputType="text"
+            android:padding="0dp"
+            tools:hint="보물찾기할 장소를 검색해 보세요" />
+    </com.google.android.material.textfield.TextInputLayout>
+
+    <ImageButton
+        android:id="@+id/ib_cancel"
+        android:layout_width="40dp"
+        android:layout_height="40dp"
+        android:layout_marginEnd="15dp"
+        android:background="@android:color/transparent"
+        android:src="@drawable/icon_cancel"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="@id/til_search_map_place" />
+
+    <View
+        android:id="@+id/v_top_separator"
+        android:layout_width="0dp"
+        android:layout_height="1dp"
+        android:layout_marginHorizontal="15dp"
+        android:layout_marginTop="15dp"
+        android:background="@color/gray_100"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/til_search_map_place" />
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/rv_search_result"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="15dp"
+        app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/v_top_separator"
+        tools:listitem="@layout/item_search_map_place" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_search_map_place.xml
+++ b/app/src/main/res/layout/fragment_search_map_place.xml
@@ -31,7 +31,7 @@
             android:id="@+id/tiet_search_bar"
             android:layout_width="250dp"
             android:layout_height="40dp"
-            android:textSize="16dp"
+            android:textSize="16sp"
             android:fontFamily="@font/pretendard"
             android:hint="@string/home_map_tiet_search_place_hint"
             android:imeOptions="actionSearch"

--- a/app/src/main/res/layout/fragment_search_map_place.xml
+++ b/app/src/main/res/layout/fragment_search_map_place.xml
@@ -18,7 +18,7 @@
         app:layout_constraintTop_toTopOf="parent" />
 
     <com.google.android.material.textfield.TextInputLayout
-        android:id="@+id/til_search_map_place"
+        android:id="@+id/til_search_bar"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         app:boxStrokeWidth="0dp"
@@ -28,9 +28,10 @@
         app:layout_constraintTop_toTopOf="@id/ib_back">
 
         <com.google.android.material.textfield.TextInputEditText
-            android:id="@+id/tiet_search_map_place"
+            android:id="@+id/tiet_search_bar"
             android:layout_width="250dp"
             android:layout_height="40dp"
+            android:textSize="16dp"
             android:fontFamily="@font/pretendard"
             android:hint="@string/home_map_tiet_search_place_hint"
             android:imeOptions="actionSearch"
@@ -47,7 +48,7 @@
         android:background="@android:color/transparent"
         android:src="@drawable/icon_cancel"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toTopOf="@id/til_search_map_place" />
+        app:layout_constraintTop_toTopOf="@id/til_search_bar" />
 
     <View
         android:id="@+id/v_top_separator"
@@ -58,7 +59,7 @@
         android:background="@color/gray_100"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/til_search_map_place" />
+        app:layout_constraintTop_toBottomOf="@id/til_search_bar" />
 
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/rv_search_result"

--- a/app/src/main/res/layout/item_search_map_place.xml
+++ b/app/src/main/res/layout/item_search_map_place.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <ImageView
+        android:id="@+id/iv_location"
+        android:layout_width="24dp"
+        android:layout_height="24dp"
+        android:layout_marginStart="15dp"
+        android:layout_marginTop="15dp"
+        android:src="@drawable/ic_location"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <TextView
+        android:id="@+id/tv_title"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="10dp"
+        android:layout_marginTop="10dp"
+        android:fontFamily="@font/pretendard"
+        android:maxWidth="260dp"
+        android:textSize="20sp"
+        app:layout_constraintStart_toEndOf="@id/iv_location"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:text="탐앤탐스 대한항공서소문점" />
+
+    <TextView
+        android:id="@+id/tv_road_address"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:ellipsize="end"
+        android:fontFamily="@font/pretendard"
+        android:maxWidth="260dp"
+        android:maxLines="1"
+        android:scrollHorizontally="true"
+        android:textColor="@color/gray_200"
+        android:textSize="14sp"
+        app:layout_constraintStart_toStartOf="@id/tv_title"
+        app:layout_constraintTop_toBottomOf="@id/tv_title"
+        tools:text="서울특별시 중구 서소문로 117 대한항공빌딩 1층" />
+
+    <TextView
+        android:id="@+id/tv_category"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="10dp"
+        android:layout_marginEnd="20dp"
+        android:fontFamily="@font/pretendard"
+        android:maxWidth="60dp"
+        android:textColor="@color/gray_100"
+        android:textSize="14sp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:text="카페" />
+
+    <TextView
+        android:id="@+id/tv_distance"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="5dp"
+        android:fontFamily="@font/pretendard"
+        android:textColor="@color/gray_100"
+        android:textSize="14sp"
+        app:layout_constraintEnd_toEndOf="@id/tv_category"
+        app:layout_constraintTop_toBottomOf="@id/tv_category"
+        tools:text="110m" />
+
+    <View
+        android:id="@+id/v_btm_separator"
+        android:layout_width="0dp"
+        android:layout_height="1dp"
+        android:layout_marginHorizontal="15dp"
+        android:layout_marginTop="15dp"
+        android:background="@color/gray_300"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/tv_road_address" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/item_search_map_place.xml
+++ b/app/src/main/res/layout/item_search_map_place.xml
@@ -17,55 +17,72 @@
 
     <TextView
         android:id="@+id/tv_title"
-        android:layout_width="wrap_content"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginStart="10dp"
         android:layout_marginTop="10dp"
         android:fontFamily="@font/pretendard"
         android:maxWidth="260dp"
         android:textSize="20sp"
+        app:layout_constraintEnd_toStartOf="@id/gl"
         app:layout_constraintStart_toEndOf="@id/iv_location"
         app:layout_constraintTop_toTopOf="parent"
         tools:text="탐앤탐스 대한항공서소문점" />
 
     <TextView
         android:id="@+id/tv_road_address"
-        android:layout_width="wrap_content"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:ellipsize="end"
         android:fontFamily="@font/pretendard"
-        android:maxWidth="260dp"
         android:maxLines="1"
         android:scrollHorizontally="true"
         android:textColor="@color/gray_200"
         android:textSize="14sp"
+        app:layout_constraintEnd_toStartOf="@id/gl"
         app:layout_constraintStart_toStartOf="@id/tv_title"
         app:layout_constraintTop_toBottomOf="@id/tv_title"
         tools:text="서울특별시 중구 서소문로 117 대한항공빌딩 1층" />
 
-    <TextView
-        android:id="@+id/tv_category"
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/gl"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginTop="10dp"
+        android:orientation="vertical"
+        app:constraint_referenced_ids="tv_title,tv_road_address"
+        app:layout_constraintGuide_percent="0.75" />
+
+    <TextView
+        android:id="@+id/tv_category"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="13dp"
         android:layout_marginEnd="20dp"
+        android:ellipsize="end"
         android:fontFamily="@font/pretendard"
         android:maxWidth="60dp"
+        android:maxLines="1"
+        android:scrollHorizontally="true"
+        android:textAlignment="viewEnd"
         android:textColor="@color/gray_100"
         android:textSize="14sp"
         app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@id/gl"
         app:layout_constraintTop_toTopOf="parent"
         tools:text="카페" />
 
     <TextView
         android:id="@+id/tv_distance"
-        android:layout_width="wrap_content"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_marginTop="5dp"
+        android:layout_marginTop="3dp"
         android:fontFamily="@font/pretendard"
+        android:textAlignment="viewEnd"
         android:textColor="@color/gray_100"
         android:textSize="14sp"
         app:layout_constraintEnd_toEndOf="@id/tv_category"
+        app:layout_constraintStart_toEndOf="@id/gl"
         app:layout_constraintTop_toBottomOf="@id/tv_category"
         tools:text="110m" />
 

--- a/app/src/main/res/layout/view_info_window_selected_search_result.xml
+++ b/app/src/main/res/layout/view_info_window_selected_search_result.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="200dp"
+    android:layout_height="wrap_content">
+
+    <androidx.cardview.widget.CardView
+        android:id="@+id/cv_background"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:background="@color/white"
+        app:cardCornerRadius="20dp"
+        app:cardElevation="-1dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <TextView
+        android:id="@+id/tv_title"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="10dp"
+        android:layout_marginTop="10dp"
+        android:fontFamily="@font/pretendard"
+        android:textColor="@color/blue"
+        android:textSize="20sp"
+        app:layout_constraintEnd_toStartOf="@id/tv_category"
+        app:layout_constraintHorizontal_chainStyle="packed"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:text="탐앤탐스 역삼점" />
+
+    <TextView
+        android:id="@+id/tv_category"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="5dp"
+        android:layout_marginEnd="10dp"
+        android:ellipsize="end"
+        android:fontFamily="@font/pretendard"
+        android:scrollHorizontally="true"
+        android:textColor="@color/gray_100"
+        android:textSize="14sp"
+        app:layout_constraintBottom_toBottomOf="@id/tv_title"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@id/tv_title"
+        app:layout_constraintTop_toTopOf="@id/tv_title"
+        tools:text="카페" />
+
+    <TextView
+        android:id="@+id/tv_distance"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="5dp"
+        android:fontFamily="@font/pretendard_semibold"
+        android:textSize="16sp"
+        app:layout_constraintStart_toStartOf="@id/tv_title"
+        app:layout_constraintTop_toBottomOf="@id/tv_title"
+        tools:text="81m" />
+
+    <TextView
+        android:id="@+id/tv_road_address"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="5dp"
+        android:layout_marginEnd="10dp"
+        android:ellipsize="end"
+        android:fontFamily="@font/pretendard"
+        android:maxLines="2"
+        android:textSize="12sp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@id/tv_distance"
+        app:layout_constraintTop_toTopOf="@id/tv_distance"
+        tools:text="서울특별시 강남구 논현로 338 블라블라" />
+
+    <ImageView
+        android:id="@+id/iv_test"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="5dp"
+        android:layout_marginBottom="10dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/tv_road_address"
+        tools:src="@drawable/ic_launcher_foreground" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -61,6 +61,11 @@
             android:defaultValue="@null"
             app:argType="string"
             app:nullable="true" />
+        <argument
+            android:name="mapPlacePosition"
+            android:defaultValue="@null"
+            app:argType="com.naver.maps.geometry.LatLng"
+            app:nullable="true" />
     </fragment>
 
     <fragment
@@ -181,7 +186,7 @@
             android:id="@+id/action_searchMapPlaceFragment_to_homeFragment"
             app:destination="@id/homeFragment" />
         <argument
-            android:name="latlng"
+            android:name="userPosition"
             app:argType="com.naver.maps.geometry.LatLng" />
     </fragment>
 </navigation>

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -53,6 +53,9 @@
             app:destination="@id/feedFragment"
             app:popUpTo="@id/homeFragment"
             app:popUpToInclusive="true" />
+        <action
+            android:id="@+id/action_homeFragment_to_searchMapPlaceFragment"
+            app:destination="@id/searchMapPlaceFragment" />
         <argument
             android:name="remotePlaceId"
             android:defaultValue="@null"
@@ -164,9 +167,18 @@
         android:id="@+id/deleteUserFragment"
         android:name="com.treasurehunt.ui.setting.DeleteAccountFragment"
         android:label="DeleteUserFragment"
-        tools:layout="@layout/fragment_delete_user" >
+        tools:layout="@layout/fragment_delete_user">
         <action
             android:id="@+id/action_deleteUserFragment_to_logInFragment"
             app:destination="@id/logInFragment" />
     </dialog>
+    <fragment
+        android:id="@+id/searchMapPlaceFragment"
+        android:name="com.treasurehunt.ui.searchmapplace.SearchMapPlaceFragment"
+        android:label="fragment_search_map_place"
+        tools:layout="@layout/fragment_search_map_place">
+        <action
+            android:id="@+id/action_searchMapPlaceFragment_to_homeFragment"
+            app:destination="@id/homeFragment" />
+    </fragment>
 </navigation>

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -62,9 +62,9 @@
             app:argType="string"
             app:nullable="true" />
         <argument
-            android:name="mapPlacePosition"
+            android:name="mapPlace"
             android:defaultValue="@null"
-            app:argType="com.naver.maps.geometry.LatLng"
+            app:argType="com.treasurehunt.ui.model.MapPlaceModel"
             app:nullable="true" />
     </fragment>
 

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -180,5 +180,8 @@
         <action
             android:id="@+id/action_searchMapPlaceFragment_to_homeFragment"
             app:destination="@id/homeFragment" />
+        <argument
+            android:name="latlng"
+            app:argType="com.naver.maps.geometry.LatLng" />
     </fragment>
 </navigation>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -8,6 +8,7 @@
     <!-- 홈 지도 화면 -->
     <string name="home_map">지도</string>
     <string name="home_feed">피드</string>
+    <string name="home_map_tiet_search_place_hint">보물찾기할 장소를 검색해 보세요</string>
 
     <!-- 지도 다이얼로그 -->
     <string name="map_prompt">%1$s를 보물상자로 지정할까요?</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -16,6 +16,9 @@
     <string name="map_answer_plan">네, 가볼래요</string>
     <string name="map_answer_no">아니요</string>
 
+    <!-- 지도 장소 검색 화면 -->
+    <string name="search_map_place_unknown">?</string>
+
     <!-- 로그인 화면 -->
     <string name="login_naver">네이버로 계속하기</string>
     <string name="login_non_member">비회원으로 로그인</string>


### PR DESCRIPTION
- [x] 홈 지도 화면 상단 검색바 클릭시, 검색 화면으로 이동
- [x] 검색 화면의 텍스트 필드에 입력시, 네이버 지역 검색 API로 결과 반환해 표시 (API에 의해 결과 5개로 제한 & 위치 기반 검색 제공 X)
- [x] 검색 결과의 장소 항목 클릭시, 홈 지도 화면으로 돌아와 해당 위치로 이동
- [x] 위치 오버레이 아이콘에 프로필 이미지 적용 (프로필 화면에서 변경시, 반영)

제가 구상한 기본 요구사항은 반영된 것 같고, 네이버 로그인 및 비회원 로그인 둘다 테스트 결과 이상 없었습니다

언젠가 구현하면 좋을 추가 기능들
- 검색 결과 항목 클릭시 바로 홈 지도 화면으로 이동하기보다, 지도에 바텀 시트로 검색 결과들 띄워주기 (네이버 지도 앱 참고)
- 최근 검색어
- 현재 카메라 위치 기반으로 검색 API 쿼리 수정
- [홈 지도 화면] 지도의 장소 클릭시, 다이얼로그 외에 장소 설명 띄워주기

-- 추가 사항 --
- 검색 결과 항목 클릭시, 해당 장소의 MapSymbol 위에 정보창 표시 및 카메라 줌인