### PR TITLE
[스플래시/로그인 화면] PreloadFragment에서 프로필 이미지 preload시, Glide에 전달하는 storageRef 변경해 Glide load fail 오류 해결

### DIFF
--- a/app/src/main/java/com/treasurehunt/ui/login/LoginViewModel.kt
+++ b/app/src/main/java/com/treasurehunt/ui/login/LoginViewModel.kt
@@ -1,5 +1,6 @@
 package com.treasurehunt.ui.login
 
+import android.net.Uri
 import androidx.lifecycle.ViewModel
 import com.google.firebase.auth.FirebaseUser
 import com.google.firebase.ktx.Firebase
@@ -49,8 +50,9 @@ class LoginViewModel @Inject constructor(
         if (profileImageUrl == null) return null
 
         val filename = profileImageUrl.extractDigits()
-        val profileImageStorageRef =
-            Firebase.storage.reference.child(currentUser.uid).child(STORAGE_LOCATION_PROFILE_IMAGE)
+        val profileImageStorageRef = Firebase.storage.reference
+                .child(currentUser.uid)
+                .child(STORAGE_LOCATION_PROFILE_IMAGE)
                 .child("$filename$FILENAME_EXTENSION_PNG")
         val input = withContext(Dispatchers.IO) {
             URL(profileImageUrl).openStream()
@@ -95,7 +97,9 @@ class LoginViewModel @Inject constructor(
     }
 
 
-    suspend fun getProfileImageStorageUrl(uid: String): String? {
+    suspend fun getProfileImageStorageUrl(uid: String?): String? {
+        if (uid == null) return null
+
         val user = userRepo.getRemoteUserById(uid)
         return user.profileImage
     }

--- a/app/src/main/java/com/treasurehunt/ui/login/PreloadFragment.kt
+++ b/app/src/main/java/com/treasurehunt/ui/login/PreloadFragment.kt
@@ -1,8 +1,15 @@
 package com.treasurehunt.ui.login
 
+import android.graphics.drawable.Drawable
+import android.util.Log
 import androidx.fragment.app.Fragment
 import com.bumptech.glide.Glide
+import com.bumptech.glide.load.DataSource
+import com.bumptech.glide.load.engine.GlideException
+import com.bumptech.glide.request.RequestListener
+import com.google.firebase.Firebase
 import com.google.firebase.auth.FirebaseUser
+import com.google.firebase.storage.storage
 
 abstract class PreloadFragment : Fragment() {
 
@@ -11,9 +18,11 @@ abstract class PreloadFragment : Fragment() {
     protected suspend fun preloadProfileImage(currentUser: FirebaseUser?) {
         if (currentUser == null) return
 
-        val profileImageStorageUrl = viewModel.getProfileImageStorageUrl(currentUser.uid) ?: return
+        val storageUrl = viewModel.getProfileImageStorageUrl(currentUser.uid) ?: return
+        val storageRef = Firebase.storage.getReferenceFromUrl(storageUrl)
+
         Glide.with(requireContext())
-            .load(profileImageStorageUrl)
+            .load(storageRef)
             .preload()
     }
 }

--- a/app/src/main/java/com/treasurehunt/ui/profile/ProfileFragment.kt
+++ b/app/src/main/java/com/treasurehunt/ui/profile/ProfileFragment.kt
@@ -1,7 +1,9 @@
 package com.treasurehunt.ui.profile
 
+import android.graphics.drawable.Drawable
 import android.os.Build
 import android.os.Bundle
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -12,6 +14,9 @@ import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
 import com.bumptech.glide.Glide
+import com.bumptech.glide.load.DataSource
+import com.bumptech.glide.load.engine.GlideException
+import com.bumptech.glide.request.RequestListener
 import com.google.android.material.tabs.TabLayoutMediator
 import com.google.firebase.Firebase
 import com.google.firebase.storage.storage
@@ -77,10 +82,10 @@ class ProfileFragment : Fragment() {
     private fun addImage(result: ActivityResult) {
         val contentUri: String = result.data?.data?.toString() ?: return
         viewModel.addImageContentUri(contentUri)
-        loadProfileImage(contentUri)
+        loadProfileImagePreview(contentUri)
     }
 
-    private fun loadProfileImage(contentUri: String) {
+    private fun loadProfileImagePreview(contentUri: String) {
         binding.ivProfileImage.run {
             Glide.with(context)
                 .load(contentUri)
@@ -118,11 +123,11 @@ class ProfileFragment : Fragment() {
     private fun loadProfileImage(user: UserDTO?) {
         binding.ivProfileImage.run {
             try {
-                val profileImageStorageRef = user?.profileImage?.let {
-                    Firebase.storage.getReferenceFromUrl(it)
-                }
+                val storageUrl = user?.profileImage ?: return
+                val storageRef = Firebase.storage.getReferenceFromUrl(storageUrl)
+
                 Glide.with(context)
-                    .load(profileImageStorageRef)
+                    .load(storageRef)
                     .error(R.drawable.ic_no_profile_image)
                     .into(this)
             } catch (e: Exception) {


### PR DESCRIPTION
** 오류 발견: 기존에 스플래시 화면 및 로그인 화면에서 Glide preload 함수로 프로필 이미지를 미리 캐시에 로드하여 프로필 화면에 진입할 때 빨리 로딩시켜주려고 구현한 코드에서 오류 발견
** 오류 내용: 글라이드 load 함수에 전달한 스토리지 reference 값을 아래처럼 구했는데, StorageException: No such object at location
        val filename = profileImageUrl.extractDigits()
        val profileImageStorageRef =
            Firebase.storage.reference.child(currentUser.uid).child(STORAGE_LOCATION_PROFILE_IMAGE)
                .child("$filename$FILENAME_EXTENSION_PNG")
** 오류 원인: ref 값을 위처럼 구하면 안 되고, getReferenceFromUrl 함수를 활용해야 함
** 해결 이후: preload 정상 동작 -> 프로필 화면 진입시, 디스크캐시의 이미지를 불러옴!

- 혹시 제가 잘못 알고 있는 부분 있다면, 피드백 주시면 감사하겠습니다!
- 데이터소스 확인해보고 싶으신 분 계실까 하여 주석처리해놓은 Logcat 코드 남겨놨습니다