### PR TITLE
[홈 지도 화면 -> 기록 상세 화면] 수정 중인 기록의 보물상자 마커를 클릭해 상세 화면 진입시 오류 해결

### DIFF
--- a/app/src/main/java/com/treasurehunt/ui/detail/LogDetailFragment.kt
+++ b/app/src/main/java/com/treasurehunt/ui/detail/LogDetailFragment.kt
@@ -8,6 +8,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.PopupMenu
 import android.widget.Toast
+import androidx.core.view.isVisible
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
@@ -62,12 +63,24 @@ class LogDetailFragment : BottomSheetDialogFragment() {
     private fun loadLog() {
         viewLifecycleOwner.lifecycleScope.launch {
             viewModel.log.collect { log ->
-                if (log == null) return@collect
+                if (log == null) {
+                    showLoadingBar()
+                    return@collect
+                }
 
+                hideLoadingBar()
                 setTextAndImages(log)
                 setDotsIndicator()
             }
         }
+    }
+
+    private fun showLoadingBar() {
+        binding.cpiLoading.isVisible = true
+    }
+
+    private fun hideLoadingBar() {
+        binding.cpiLoading.isVisible = false
     }
 
     private fun setTextAndImages(log: LogModel) {

--- a/app/src/main/java/com/treasurehunt/ui/detail/LogDetailViewModel.kt
+++ b/app/src/main/java/com/treasurehunt/ui/detail/LogDetailViewModel.kt
@@ -24,6 +24,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlinx.serialization.SerializationException
 import javax.inject.Inject
 
 private const val STORAGE_LOCATION_USER_IMAGES = "%s/$STORAGE_LOCATION_LOG_IMAGES"
@@ -50,12 +51,25 @@ class LogDetailViewModel @Inject constructor(
         viewModelScope.launch {
             val placeId = LogDetailFragmentArgs.fromSavedStateHandle(savedStateHandle).remotePlaceId
             val log = if (placeId.isNotEmpty()) {
-                getLogByRemotePlaceId(placeId)
+                getSafeLogByRemotePlaceId(placeId)
             } else {
                 args.log
             }
             _log.update { log }
         }
+    }
+
+    private suspend fun getSafeLogByRemotePlaceId(placeId: String): LogModel? {
+        var field: LogModel?
+        while (true) {
+            try {
+                field = getLogByRemotePlaceId(placeId)
+                break
+            } catch (e: SerializationException) {
+                continue
+            }
+        }
+        return field
     }
 
     suspend fun getMapSymbol(log: LogModel? = null, remotePlaceId: String = ""): MapSymbol {

--- a/app/src/main/res/layout/fragment_logdetail.xml
+++ b/app/src/main/res/layout/fragment_logdetail.xml
@@ -9,6 +9,17 @@
     android:paddingEnd="0dp"
     android:paddingBottom="16dp">
 
+    <com.google.android.material.progressindicator.CircularProgressIndicator
+        android:id="@+id/cpi_loading"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:indeterminate="true"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_bias="0.4" />
+
     <ImageButton
         android:id="@+id/btn_popup"
         android:layout_width="20dp"


### PR DESCRIPTION
오류 현상:  수정 중인 기록의 보물상자 마커를 클릭해 상세 화면 진입시 런타임 에러
오류 원인: Firebase Realtime Database에서 PATCH 쿼리문을 통해 레코드 업데이트시, 해당 레코드가 통째로 삭제된 후 새로 추가됨 -> 그래서 삭제된 시점에 해당 레코드를 조회하면, null 값이 반환되고, 이를 LogDTO 타입으로 역직렬화하려고 하니 JSONDecodingException 발생
오류 해결: 기록 상세 화면의 뷰모델에서 원격 DB에서 기록 데이터를 조회할 때, while 문 속에 try catch를 반복시켜 값을 반환할 때까지 루프를 돌림