### PR TITLE
[기록 상세 화면] 수정/삭제 기능을 피드 화면에서 진입한 경우도 구분해서 적용

### DIFF
--- a/app/src/main/java/com/treasurehunt/data/local/model/LogEntity.kt
+++ b/app/src/main/java/com/treasurehunt/data/local/model/LogEntity.kt
@@ -24,4 +24,4 @@ fun LogEntity.toLogDTO() =
     LogDTO(remotePlaceId, text, theme, createdDate, remoteImageIds.associateWith { true }, localId)
 
 fun LogEntity.toLogModel(imagesUrls: List<String>) =
-    LogModel(remotePlaceId, text, theme, createdDate, remoteImageIds, imagesUrls)
+    LogModel(remotePlaceId, text, theme, createdDate, remoteImageIds, imagesUrls, localId, remoteId)

--- a/app/src/main/java/com/treasurehunt/ui/detail/LogDetailFragment.kt
+++ b/app/src/main/java/com/treasurehunt/ui/detail/LogDetailFragment.kt
@@ -8,6 +8,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.PopupMenu
 import android.widget.Toast
+import androidx.core.view.isVisible
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
@@ -62,12 +63,24 @@ class LogDetailFragment : BottomSheetDialogFragment() {
     private fun loadLog() {
         viewLifecycleOwner.lifecycleScope.launch {
             viewModel.log.collect { log ->
-                if (log == null) return@collect
+                if (log == null) {
+                    showLoadingBar()
+                    return@collect
+                }
 
+                hideLoadingBar()
                 setTextAndImages(log)
                 setDotsIndicator()
             }
         }
+    }
+
+    private fun showLoadingBar() {
+        binding.cpiLoading.isVisible = true
+    }
+
+    private fun hideLoadingBar() {
+        binding.cpiLoading.isVisible = false
     }
 
     private fun setTextAndImages(log: LogModel) {

--- a/app/src/main/java/com/treasurehunt/ui/detail/LogDetailFragment.kt
+++ b/app/src/main/java/com/treasurehunt/ui/detail/LogDetailFragment.kt
@@ -144,7 +144,7 @@ class LogDetailFragment : BottomSheetDialogFragment() {
                 }
 
                 val mapSymbol = viewModel.run {
-                    getMapSymbol(args.log, args.remotePlaceId)
+                    getMapSymbol(args.remotePlaceId, args.log)
                 }
                 val action = LogDetailFragmentDirections.actionLogDetailFragmentToSaveLogFragment(
                     mapSymbol, logResult.value

--- a/app/src/main/java/com/treasurehunt/ui/detail/LogDetailFragment.kt
+++ b/app/src/main/java/com/treasurehunt/ui/detail/LogDetailFragment.kt
@@ -160,7 +160,7 @@ class LogDetailFragment : BottomSheetDialogFragment() {
             val placeId = viewModel.args.remotePlaceId
             val log = viewModel.args.log
 
-            if (placeId.isNotEmpty()) {
+            if (placeId != null) {
                 handleDeleteFromHome(placeId, userId)
             } else if (log != null) {
                 handleDeleteFromFeed(log, userId)

--- a/app/src/main/java/com/treasurehunt/ui/detail/LogDetailViewModel.kt
+++ b/app/src/main/java/com/treasurehunt/ui/detail/LogDetailViewModel.kt
@@ -51,7 +51,7 @@ class LogDetailViewModel @Inject constructor(
     private fun initLog() {
         viewModelScope.launch {
             val placeId = LogDetailFragmentArgs.fromSavedStateHandle(savedStateHandle).remotePlaceId
-            val logResult = if (placeId.isNotEmpty()) {
+            val logResult = if (placeId != null) {
                 getSafeLogByRemotePlaceId(placeId)
             } else {
                 getSafeLogByRemoteLogId(args.log?.remoteId)
@@ -111,8 +111,8 @@ class LogDetailViewModel @Inject constructor(
         return logDTO.toLogModel(imageUrls, logDTO.localId, logId)
     }
 
-    suspend fun getMapSymbol(log: LogModel? = null, remotePlaceId: String = ""): MapSymbol {
-        val placeId = remotePlaceId.ifEmpty { log!!.remotePlaceId }
+    suspend fun getMapSymbol(log: LogModel? = null, remotePlaceId: String? = null): MapSymbol {
+        val placeId = remotePlaceId ?: log!!.remotePlaceId
         val placeDTO = placeRepo.getRemotePlaceById(placeId)
         return placeDTO.toMapSymbol()
     }

--- a/app/src/main/java/com/treasurehunt/ui/detail/LogDetailViewModel.kt
+++ b/app/src/main/java/com/treasurehunt/ui/detail/LogDetailViewModel.kt
@@ -24,6 +24,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlinx.serialization.SerializationException
 import javax.inject.Inject
 
 private const val STORAGE_LOCATION_USER_IMAGES = "%s/$STORAGE_LOCATION_LOG_IMAGES"
@@ -50,12 +51,25 @@ class LogDetailViewModel @Inject constructor(
         viewModelScope.launch {
             val placeId = LogDetailFragmentArgs.fromSavedStateHandle(savedStateHandle).remotePlaceId
             val log = if (placeId.isNotEmpty()) {
-                getLogByRemotePlaceId(placeId)
+                getSafeLogByRemotePlaceId(placeId)
             } else {
                 args.log
             }
             _log.update { log }
         }
+    }
+
+    private suspend fun getSafeLogByRemotePlaceId(placeId: String): LogModel? {
+        var field: LogModel?
+        while (true) {
+            try {
+                field = getLogByRemotePlaceId(placeId)
+                break
+            } catch (e: SerializationException) {
+                continue
+            }
+        }
+        return field
     }
 
     suspend fun getMapSymbol(log: LogModel? = null, remotePlaceId: String = ""): MapSymbol {

--- a/app/src/main/java/com/treasurehunt/ui/detail/LogDetailViewModel.kt
+++ b/app/src/main/java/com/treasurehunt/ui/detail/LogDetailViewModel.kt
@@ -37,7 +37,7 @@ class LogDetailViewModel @Inject constructor(
     private val logRepo: LogRepository,
     private val userRepo: UserRepository,
     private val imageRepo: ImageRepository,
-    private val savedStateHandle: SavedStateHandle,
+    savedStateHandle: SavedStateHandle,
 ) : ViewModel() {
 
     val args = LogDetailFragmentArgs.fromSavedStateHandle(savedStateHandle)
@@ -50,11 +50,14 @@ class LogDetailViewModel @Inject constructor(
 
     private fun initLog() {
         viewModelScope.launch {
-            val placeId = LogDetailFragmentArgs.fromSavedStateHandle(savedStateHandle).remotePlaceId
+            val placeId = args.remotePlaceId
+            val log = args.log
             val logResult = if (placeId != null) {
                 getSafeLogByRemotePlaceId(placeId)
+            } else if (log != null) {
+                getSafeLogByRemoteLogId(log.remoteId)
             } else {
-                getSafeLogByRemoteLogId(args.log?.remoteId)
+                LogResult.LogNotLoaded
             }
             _logResult.update { logResult }
         }
@@ -111,7 +114,7 @@ class LogDetailViewModel @Inject constructor(
         return logDTO.toLogModel(imageUrls, logDTO.localId, logId)
     }
 
-    suspend fun getMapSymbol(log: LogModel? = null, remotePlaceId: String? = null): MapSymbol {
+    suspend fun getMapSymbol(remotePlaceId: String? = null, log: LogModel? = null): MapSymbol {
         val placeId = remotePlaceId ?: log!!.remotePlaceId
         val placeDTO = placeRepo.getRemotePlaceById(placeId)
         return placeDTO.toMapSymbol()

--- a/app/src/main/java/com/treasurehunt/ui/detail/LogResult.kt
+++ b/app/src/main/java/com/treasurehunt/ui/detail/LogResult.kt
@@ -1,0 +1,12 @@
+package com.treasurehunt.ui.detail
+
+import com.treasurehunt.ui.model.LogModel
+
+sealed class LogResult {
+
+    data class LogLoaded(val value: LogModel) : LogResult()
+
+    data object LogLoading : LogResult()
+
+    data object LogNotLoaded : LogResult()
+}

--- a/app/src/main/java/com/treasurehunt/ui/feed/FeedViewModel.kt
+++ b/app/src/main/java/com/treasurehunt/ui/feed/FeedViewModel.kt
@@ -25,6 +25,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlinx.serialization.SerializationException
 import javax.inject.Inject
 
 private const val INITIAL_LOAD_SIZE = 3
@@ -56,8 +57,12 @@ class FeedViewModel @Inject constructor(
     }
 
     private suspend fun getImageUrls(imageIds: List<String>): List<String> {
-        return imageIds.map { id ->
-            imageRepo.getRemoteImageById(id).url
+        return try {
+            imageIds.map { id ->
+                imageRepo.getRemoteImageById(id).url
+            }
+        } catch (e: SerializationException) {
+            listOf("")
         }
     }
 }

--- a/app/src/main/java/com/treasurehunt/ui/model/LogModel.kt
+++ b/app/src/main/java/com/treasurehunt/ui/model/LogModel.kt
@@ -17,7 +17,7 @@ data class LogModel(
     val remoteId: String? = null
 ) : Parcelable
 
-fun LogModel.asLogEntity(localId: Long = 0, remoteId: String? = null) =
+fun LogModel.asLogEntity(localId: Long = 0, remoteId: String? = this.remoteId) =
     LogEntity(remotePlaceId, text, theme, createdDate, remoteImageIds, localId, remoteId)
 
 fun LogModel.asLogDTO(localId: Long = 0) =

--- a/app/src/main/java/com/treasurehunt/ui/savelog/DatabaseUpdateWorker.kt
+++ b/app/src/main/java/com/treasurehunt/ui/savelog/DatabaseUpdateWorker.kt
@@ -3,6 +3,7 @@ package com.treasurehunt.ui.savelog
 import android.content.Context
 import androidx.hilt.work.HiltWorker
 import androidx.work.CoroutineWorker
+import androidx.work.Data
 import androidx.work.WorkerParameters
 import com.treasurehunt.data.ImageRepository
 import com.treasurehunt.data.LogRepository
@@ -31,34 +32,22 @@ class DatabaseUpdateWorker @AssistedInject constructor(
     private val imageRepo: ImageRepository
 ) : CoroutineWorker(context, params) {
 
-    private val uid = inputData.getString(WORK_DATA_UID) ?: ""
-    private lateinit var mapSymbol: MapSymbol
-    private val localLogId = inputData.getLong(WORK_DATA_LOCAL_LOG_ID, -1)
-    private val remoteLogId = inputData.getString(WORK_DATA_REMOTE_LOG_ID)
-    private var localPlaceId = -1L
-    private val remotePlaceId = inputData.getString(WORK_DATA_REMOTE_PLACE_ID)
-
     override suspend fun doWork(): Result {
-        remotePlaceId?.let { remotePlaceId ->
-            localPlaceId = placeRepo.getRemotePlaceById(remotePlaceId).localId
-        }
-
         return try {
-            if (uid.isEmpty()) return Result.failure()
-
-            val urlStrings = inputData.getStringArray(WORK_DATA_URL_STRINGS)?.asList()
+            val mapSymbol: MapSymbol = mapSymbolOf(inputData)
+            val remotePlaceId = inputData.getString(WORK_DATA_REMOTE_PLACE_ID)
+                ?: getRemotePlaceId(mapSymbol)
+            val log = logOf(inputData, remotePlaceId)
                 ?: return Result.failure()
-            val text = inputData.getString(WORK_DATA_LOG_TEXT)
-                ?: return Result.failure()
-            val lat = inputData.getDouble(WORK_DATA_LAT, 0.0)
-            val lng = inputData.getDouble(WORK_DATA_LNG, 0.0)
-            val caption = inputData.getString(WORK_DATA_CAPTION) ?: ""
-            val isPlan = inputData.getBoolean(WORK_DATA_IS_PLAN, false)
-            val planId = inputData.getString(WORK_DATA_PLAN_ID)
+            val localLogId = inputData.getLong(WORK_DATA_LOCAL_LOG_ID, -1)
+            val remoteLogId = inputData.getString(WORK_DATA_REMOTE_LOG_ID)?.also { remoteLogId ->
+                updateLog(log, localLogId, remoteLogId)
+            } ?: insertLog(log)
+            val uid = inputData.getString(WORK_DATA_UID) ?: return Result.failure()
 
-            mapSymbol = MapSymbol(lat, lng, isPlan, caption, planId)
+            updatePlaceWithLog(remotePlaceId, remoteLogId)
 
-            init(urlStrings, text)
+            updateUser(uid, remotePlaceId, mapSymbol.remotePlanId, remoteLogId)
 
             Result.success()
         } catch (e: Exception) {
@@ -66,19 +55,18 @@ class DatabaseUpdateWorker @AssistedInject constructor(
         }
     }
 
-    private suspend fun init(imageStorageUrls: List<String>, text: String) {
-        val remotePlaceId = getRemotePlaceId()
-        val log = logOf(imageStorageUrls, remotePlaceId, text)
-        val remoteLogId = insertLog(log)
+    private fun mapSymbolOf(inputData: Data): MapSymbol {
+        val lat = inputData.getDouble(WORK_DATA_LAT, 0.0)
+        val lng = inputData.getDouble(WORK_DATA_LNG, 0.0)
+        val caption = inputData.getString(WORK_DATA_CAPTION) ?: ""
+        val isPlan = inputData.getBoolean(WORK_DATA_IS_PLAN, false)
+        val planId = inputData.getString(WORK_DATA_PLAN_ID)
 
-        updatePlaceWithLog(remotePlaceId, remoteLogId)
-        updateUser(remotePlaceId, remoteLogId)
+        return MapSymbol(lat, lng, isPlan, caption, planId)
     }
 
     // 기록 저장 화면 진입 경로 (처리 순서대로): 기록 상세 화면 수정 / 홈 지도 화면 다이얼로그 "네, 가봤어요" / 홈 지도 화면 닫힌 보물상자 마커
-    private suspend fun getRemotePlaceId(): String {
-        if (remotePlaceId != null) return remotePlaceId
-
+    private suspend fun getRemotePlaceId(mapSymbol: MapSymbol): String {
         val planId = mapSymbol.remotePlanId
         return if (planId.isNullOrEmpty()) {
             insertPlace(mapSymbol)
@@ -118,10 +106,14 @@ class DatabaseUpdateWorker @AssistedInject constructor(
     }
 
     private suspend fun logOf(
-        imageStorageUrls: List<String>,
-        remotePlaceId: String,
-        text: String
-    ): LogModel {
+        inputData: Data,
+        remotePlaceId: String
+    ): LogModel? {
+        val imageStorageUrls = inputData.getStringArray(WORK_DATA_URL_STRINGS)?.asList()
+            ?: return null
+        val text = inputData.getString(WORK_DATA_LOG_TEXT)
+            ?: return null
+
         val theme = "123"
         val createdDate = getCurrentTime()
         val imageIds = imageStorageUrls.map { imageUrl ->
@@ -139,13 +131,13 @@ class DatabaseUpdateWorker @AssistedInject constructor(
         )
     }
 
-    private suspend fun insertLog(log: LogModel): String {
-        if (remoteLogId != null) {
-            logRepo.update(log.asLogEntity(localLogId, remoteLogId))
-            logRepo.update(remoteLogId, log.asLogDTO(localLogId))
-            return remoteLogId
-        }
+    private suspend fun updateLog(log: LogModel, localLogId: Long, remoteLogId: String): String {
+        logRepo.update(log.asLogEntity(localLogId, remoteLogId))
+        logRepo.update(remoteLogId, log.asLogDTO(localLogId))
+        return remoteLogId
+    }
 
+    private suspend fun insertLog(log: LogModel): String {
         val localLogId = logRepo.insert(log.asLogEntity())
         val remoteLogId = logRepo.insert(log.asLogDTO(localLogId))
         logRepo.update(log.asLogEntity(localLogId, remoteLogId))
@@ -158,21 +150,23 @@ class DatabaseUpdateWorker @AssistedInject constructor(
         placeRepo.update(remotePlaceId, updatedPlace)
     }
 
-    private suspend fun updateUser(remotePlaceId: String, remoteLogId: String) {
+    private suspend fun updateUser(
+        uid: String,
+        remotePlaceId: String,
+        remotePlanId: String?,
+        remoteLogId: String
+    ) {
         val userDTO = userRepo.getRemoteUserById(uid)
-
-        if (!mapSymbol.remotePlanId.isNullOrEmpty()) {
-            userRepo.update(
-                uid, userDTO.copy(
-                    remotePlanIds = userDTO.remotePlanIds.minus(remotePlaceId)
-                )
-            )
-        }
 
         userRepo.update(
             uid, userDTO.copy(
+                remoteLogIds = userDTO.remoteLogIds.plus(remoteLogId to true),
                 remoteVisitIds = userDTO.remoteVisitIds.plus(remotePlaceId to true),
-                remoteLogIds = userDTO.remoteLogIds.plus(remoteLogId to true)
+                remotePlanIds = if (remotePlanId != null) {
+                    userDTO.remotePlanIds.minus(remotePlanId)
+                } else {
+                    userDTO.remotePlanIds
+                }
             )
         )
     }

--- a/app/src/main/java/com/treasurehunt/ui/savelog/SaveLogFragment.kt
+++ b/app/src/main/java/com/treasurehunt/ui/savelog/SaveLogFragment.kt
@@ -223,7 +223,7 @@ class SaveLogFragment : Fragment(), OnMapReadyCallback {
 
             scheduleImageUploadAndDatabaseUpdateWorks()
 
-            findNavController().navigate(R.id.action_saveLogFragment_to_homeFragment)
+            findNavController().navigateUp()
         }
     }
 
@@ -284,7 +284,6 @@ class SaveLogFragment : Fragment(), OnMapReadyCallback {
             .putStringArray(WORK_DATA_URL_STRINGS, storageUrls)
             .apply {
                 args.log?.let { log ->
-                    // TODO: check Feed
                     requireNotNull(log.remoteId)
                     putString(WORK_DATA_REMOTE_LOG_ID, log.remoteId)
                 }
@@ -320,7 +319,6 @@ class SaveLogFragment : Fragment(), OnMapReadyCallback {
             .putString(WORK_DATA_PLAN_ID, planId)
             .apply {
                 args.log?.let { log ->
-                    // TODO: check Feed
                     requireNotNull(log.localId)
                     requireNotNull(log.remoteId)
                     requireNotNull(log.remotePlaceId)

--- a/app/src/main/res/layout/fragment_logdetail.xml
+++ b/app/src/main/res/layout/fragment_logdetail.xml
@@ -9,6 +9,17 @@
     android:paddingEnd="0dp"
     android:paddingBottom="16dp">
 
+    <com.google.android.material.progressindicator.CircularProgressIndicator
+        android:id="@+id/cpi_loading"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:indeterminate="true"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_bias="0.4" />
+
     <ImageButton
         android:id="@+id/btn_popup"
         android:layout_width="20dp"

--- a/app/src/main/res/layout/fragment_logdetail.xml
+++ b/app/src/main/res/layout/fragment_logdetail.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:background="@drawable/bottom_sheet_background"
@@ -19,6 +20,23 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintVertical_bias="0.4" />
+
+    <TextView
+        android:id="@+id/tv_load_fail"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:fontFamily="@font/pretendard"
+        android:text="@string/logdetail_log_failed"
+        android:textAlignment="center"
+        android:textColor="@color/gray_100"
+        android:textSize="16sp"
+        android:visibility="gone"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_bias="0.4"
+        tools:visibility="visible" />
 
     <ImageButton
         android:id="@+id/btn_popup"

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -105,6 +105,9 @@
         <action
             android:id="@+id/action_logDetailFragment_to_saveLogFragment"
             app:destination="@id/saveLogFragment" />
+        <action
+            android:id="@+id/action_logDetailFragment_to_feedFragment"
+            app:destination="@id/feedFragment" />
         <argument
             android:name="log"
             android:defaultValue="@null"

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -115,8 +115,9 @@
             app:nullable="true" />
         <argument
             android:name="remotePlaceId"
-            android:defaultValue=""
-            app:argType="string" />
+            android:defaultValue="@null"
+            app:argType="string"
+            app:nullable="true" />
     </dialog>
 
     <fragment

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -47,6 +47,7 @@
     <string name="logdetail_content">Check out Treasure Hunt: %s</string>
     <string name="logdetail_chooser_title">내용 공유하기</string>
     <string name="logdetail_log_still_loading_message">데이터를 불러오는 중입니다. 잠시 후 다시 시도해 주세요</string>
+    <string name="logdetail_log_failed">데이터를 불러오지 못했습니다.\n잠시 후 다시 시도해 주세요.</string>
     <string name="logdetail_log_deleted_message">기록이 삭제되었습니다</string>
     <string name="logdetail_error_message">문제가 생겨 잠시 후 다시 시도해 주세요</string>
 


### PR DESCRIPTION
이전 PR 내용
- [x] 수정 중인 기록의 상세 화면 진입시 발생 에러 해결 (머지시켰다가 이번 PR에 머지된 디벨롭을 리베이스하려니 conflict이 심해서 그냥 이 PR에 해당 내용 포함시켰습니다)
피드백 반영
- [x] [기록 상세 화면에서 원격 DB의 기록 데이터 조회가 지연될 시, 오류 메시지 표시
---

- [x] 피드 화면의 기록 상세 화면에서 수정/삭제 구현 및 각각 완료 후 피드 화면으로 이동